### PR TITLE
Bug/whitespace in event image

### DIFF
--- a/events.html
+++ b/events.html
@@ -18,10 +18,6 @@
 
             <!-- Event Tiles Grid -->
             <section class="events-grid" id="eventsGrid">
-                <div class="event-section-title">
-                    <h2>Featured Events</h2>
-                    <p>Click on an event to learn more!</p>
-                </div>
                 <!-- Tiles will be dynamically injected via JavaScript -->
                 <script src="resources/js/events.js"></script>
             </section> 

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -588,10 +588,6 @@ img {
   EVENTS GRID
 ----------------------------------------------------------------------------- */
 
-.event-section-title {
-  text-align: center;
-}
-
 .events-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -657,7 +657,8 @@ img {
   padding: 0;
   margin: var(--space-xs);
   min-width: 0;
-  min-height: 120px;
+  min-height: 160px;
+  max-height: 160px;
   max-width: 100%;
   cursor: pointer;
   transition: box-shadow 0.2s, transform 0.2s;
@@ -671,7 +672,7 @@ img {
 .event-img-container {
   flex: 0 0 25%;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
   height: 100%;
   min-width: 100px;


### PR DESCRIPTION
This pull request includes updates to the `events.html` and `resources/css/style.css` files to improve the layout and styling of the events grid. The changes primarily focus on removing unused elements, adjusting image dimensions, and improving alignment for better visual consistency.

### HTML Changes:
* Removed the `event-section-title` div and its associated content (`<h2>` and `<p>` tags) from the events grid section in `events.html`, as they are no longer needed.

### CSS Changes:
* Removed the `.event-section-title` CSS class definition, as it is no longer used after the corresponding HTML changes.
* Adjusted the `img` styling to increase the `min-height` to `160px` and added a `max-height` of `160px` for consistent image dimensions.
* Updated the `.event-img-container` alignment from `align-items: center` to `align-items: stretch` to ensure images fill their container height proportionally.