### PR TITLE
fix: event page load at same time

### DIFF
--- a/event.html
+++ b/event.html
@@ -16,15 +16,15 @@
             <section class="event-detail-hero hidden" style="display:none;">
                 <div class="event-detail-content">
                     <button class="return-button">← Return to all events</button>
-                    <h1 id="eventTitle">Event Title</h1>
+                    <h1 id="eventTitle"></h1>
                     <!-- Mobile image: only shown on mobile via CSS -->
                     <div class="event-detail-image event-detail-image--mobile">
                         <img id="eventImage" src="" alt="Event Image" class="event-img">
                     </div>
-                    <p id="eventDateRange">Date</p>
-                    <p id="eventLocation">Location</p>
+                    <p id="eventDateRange"></p>
+                    <p id="eventLocation"></p>
                     <div class="event-detail-description">
-                        <p id="eventDescription">Event Description</p>
+                        <p id="eventDescription"></p>
                     </div>
                     <a id="eventICSLink" href="#" class="modal-link hidden">Add to Calendar</a>
                     <a id="eventExternalLink" href="#" target="_blank" class="modal-button hidden">Learn More</a>


### PR DESCRIPTION
This pull request makes small changes to the `event.html` file to initialize certain elements with empty content instead of placeholder text. These updates ensure that the elements (`#eventTitle`, `#eventDateRange`, `#eventLocation`, and `#eventDescription`) start with blank values, likely to be dynamically populated later.

Key changes:

* Updated the `#eventTitle`, `#eventDateRange`, `#eventLocation`, and `#eventDescription` elements to have empty content (`""`) instead of placeholder text (`"Event Title"`, `"Date"`, `"Location"`, and `"Event Description"`, respectively).