### PR TITLE
98 trigger calendar overflow modal for low screen width

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1193,6 +1193,16 @@ img {
   transition: background 0.2s;
 }
 
+@media (max-width: 615px) {
+  .calendar-more-link {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+    display: block;
+  }
+}
+
 .calendar-more-link:hover,
 .calendar-more-link:focus {
   background: var(--nyc-light-blue);

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -19,6 +19,13 @@ function formatDateId(date) {
     return date.toISOString().split('T')[0];
 }
 
+/**
+ * This function determines how many event bars are visible in the calendar grid
+ */
+function getMaxVisible() {
+  return window.innerWidth <= 860 ? 2 : 4;
+}
+
 // === UI RENDERING FUNCTIONS ===
 
 /**
@@ -158,8 +165,7 @@ function placeEventsInGrid(month, year) {
       return a.startCellIndex - b.startCellIndex;
     });
 
-
-    const maxVisible = 4; // or whatever number you want
+    const maxVisible = getMaxVisible();
     
     // Map: col (0-6) => array of {event, slot, ...}
     const eventsByDay = Array(7).fill(0).map(() => []);
@@ -346,5 +352,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             renderCalendar(currentMonth, currentYear); // Re-render with new month
         };
+        // Re-render calendar on window resize to update maxVisible
+        window.addEventListener('resize', () => {
+            renderCalendar(currentMonth, currentYear);
+        });
     }
 });


### PR DESCRIPTION
This pull request introduces responsive design improvements to the calendar component, ensuring better usability on smaller screens. The main changes include updating the maximum number of visible event bars dynamically based on screen width and adding a responsive style for the `.calendar-more-link` element.

### Responsive design updates:

* [`resources/css/style.css`](diffhunk://#diff-f69983e16ee9d68a0ef53895a6bbe177642cd1bf764de32b0822bd31ce3ad36dR1196-R1205): Added a media query for screens with a maximum width of 615px to ensure the `.calendar-more-link` text is truncated with ellipsis and displayed as a block element for better readability.

* `resources/js/calendar.js`:
  - Introduced a new `getMaxVisible` function to dynamically determine the maximum number of visible event bars in the calendar grid based on the screen width.
  - Updated the `placeEventsInGrid` function to use the `getMaxVisible` function instead of a hardcoded value.
  - Added a `resize` event listener to re-render the calendar when the window size changes, ensuring the layout updates appropriately for the new screen width.