### PR TITLE
factor: removed excess white space on events page

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -597,6 +597,22 @@ img {
   padding: var(--space-sm);
 }
 
+/* Remove extra margin and padding from the events grid section */
+section.events-grid {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  background: none !important;
+}
+
+/* Prevent empty grid from taking up space */
+#eventsGrid:empty {
+  min-height: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
 @media (max-width: 1100px) {
   .events-grid {
     grid-template-columns: repeat(2, 1fr);
@@ -1191,16 +1207,6 @@ img {
   padding: 2px 0;
   margin-top: 2px;
   transition: background 0.2s;
-}
-
-@media (max-width: 615px) {
-  .calendar-more-link {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    width: 100%;
-    display: block;
-  }
 }
 
 .calendar-more-link:hover,

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -599,10 +599,8 @@ img {
 
 /* Remove extra margin and padding from the events grid section */
 section.events-grid {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
   background: none !important;
 }
 


### PR DESCRIPTION
This pull request focuses on improving the layout and responsiveness of the events grid section in the CSS file `resources/css/style.css`. It introduces styles to remove unnecessary spacing and ensure empty grids do not occupy space, while also removing redundant media query rules.

### Layout adjustments for the events grid:

* Added styles to `section.events-grid` to remove extra margin, padding, and background, ensuring a cleaner layout.
* Introduced styles for `#eventsGrid:empty` to prevent empty grids from taking up space by setting `min-height`, `padding`, and `margin` to zero.

### Removal of redundant styles:

* Removed a media query for `.calendar-more-link` that applied text overflow and display properties, as it was deemed unnecessary.