### PR TITLE
feat: date-ideas parser

### DIFF
--- a/resources/js/date-ideas.js
+++ b/resources/js/date-ideas.js
@@ -37,22 +37,24 @@ function parseCSV(csvText, type = "date-idea") {
         }
     });
 
-    items.forEach(item => {
-        item.id = generateEventId(item);
+    items.forEach((item, idx) => {
+        item.id = generateEventId(item, idx);
     });
 
     return items;
 }
 
 /**
- * Generates a unique event ID (slug) from event name only.
- * Example output: "pizza-pop-up"
+ * Generates a unique event ID (slug) from event name and row index.
+ * Example output: "pizza-pop-up-3"
  * @param {Object} item - Item object containing name.
+ * @param {number} index - Row index to ensure uniqueness.
  * @returns {string} - Unique event ID.
  */
-function generateEventId(item) {
-    // Use item name only, lowercased and slugified
-    return (item.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+function generateEventId(item, index) {
+    // Use item name, lowercased and slugified, plus index for uniqueness
+    const base = (item.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    return `${base}-${index}`;
 }
 
 // Fetch date ideas


### PR DESCRIPTION
This pull request adds functionality to fetch and parse date ideas from a published Google Sheet in CSV format. The changes introduce utility functions for parsing CSV data and generating unique event IDs, making it easier to manage and display date ideas dynamically.

Integration of Google Sheet data:

* Added a constant `DATE_IDEAS_CSV_URL` to specify the URL of the published Google Sheet in CSV format.
* Implemented a `parseCSV` function to convert the raw CSV string into an array of event objects, handling multi-line fields and formatting descriptions appropriately.
* Added a `generateEventId` function to create unique, slugified IDs for each event based on its name.
* Included logic to fetch the CSV data from the Google Sheet, parse it, and log the resulting array of date ideas for further use.