### PR TITLE
feat: removed unwanted text

### DIFF
--- a/pop-ups.html
+++ b/pop-ups.html
@@ -35,7 +35,6 @@
                 <!-- Tiles will be dynamically injected via JavaScript using BEM/component class names -->
             </section>
             <script src="resources/js/pop-ups.js"></script>
-            <script src="resources/js/dates.js"></script>
         </main>
 
         <!-- The footer content will be dynamically loaded here -->

--- a/resources/css/popups.css
+++ b/resources/css/popups.css
@@ -27,26 +27,6 @@ section.popups-grid {
 }
 
 /* =========================
-   CALLOUT STYLES
-========================= */
-.callout {
-  margin: var(--space-md) auto;
-  padding: var(--space-sm-md);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-  max-width: var(--section-max-width);
-}
-.callout--accent {
-  background-color: var(--nyc-light-blue);
-  border: 1px solid var(--nyc-navy);
-}
-.callout p {
-  margin: 0;
-  font-style: italic;
-  text-align: center;
-}
-
-/* =========================
    EVENT TILE STYLES
 ========================= */
 .popup-tile {
@@ -314,10 +294,6 @@ section.popups-grid {
   }
   .popup-tile__text p {
     font-size: var(--font-sm);
-  }
-  .callout {
-    margin: var(--space-sm);
-    max-width: calc(100% - (2 * var(--space-sm)));
   }
 }
 /* ===============================


### PR DESCRIPTION
This pull request makes a small change to the `pop-ups.html` file by removing the contextual callout section that described the types of pop-ups featured and provided additional context for users. 

* Removed the contextual callout section from the top of the page, which previously introduced the NYC pop-ups and highlighted the types of events listed.
* Based of a request from my wife to ensure that this blurb is removed because it's taking up too much space in the mobile experience.