### PR TITLE
Fix geocoding for full addresses, intersections, and landmark venues

### DIFF
--- a/data/geocode-cache.json
+++ b/data/geocode-cache.json
@@ -1,0 +1,30 @@
+{
+  "22 Wooster, 22 Wooster St, New York, NY 10013, New York, NY": {
+    "lat": 40.7215235,
+    "lon": -74.0030602
+  },
+  "The Shack, 569 Broadway, New York, NY 10012, New York, NY": {
+    "lat": 40.724383,
+    "lon": -73.997788
+  },
+  "Shopify NY, 131 Greene St, New York, NY 10012, New York, NY": {
+    "lat": 40.7256642,
+    "lon": -73.9989626
+  },
+  "Sunday Club Newsstand, E 14th St & 3rd Ave, New York, NY 10003, New York, NY": {
+    "lat": 40.7330046,
+    "lon": -73.9867222
+  },
+  "Remedy Diner, 245 E Houston St, New York, NY 10002, New York, NY": {
+    "lat": 40.7217736,
+    "lon": -73.9854765
+  },
+  "Chelsea Triangle, W 14th St & 9th Ave, New York, NY 10014, New York, NY": {
+    "lat": 40.7412313,
+    "lon": -74.005763
+  },
+  "Domino Park, 15 River St, Brooklyn, NY 11249, New York, NY": {
+    "lat": 40.7166283,
+    "lon": -73.9665073
+  }
+}

--- a/scripts/geocode-popups.js
+++ b/scripts/geocode-popups.js
@@ -210,13 +210,40 @@ function geocodeAddress(queryText, timeoutMs = 15000) {
 // Cache + helpers
 // ---------------------------------------------------------------------------
 
-/** Builds the geocoder query string / cache key for a pop-up. Address is a
- * single unstructured text field with no city/state, so "New York, NY" is
- * appended for disambiguation. */
+/** Builds the cache key for a pop-up's location. Kept stable (venue + address
+ * + suffix) so existing cache entries stay valid even as the query strategy
+ * evolves. */
 function normalizeAddressKey(venueName, address) {
     const parts = [venueName, address].map(s => (s || '').trim()).filter(Boolean);
     if (parts.length === 0) return '';
     return `${parts.join(', ')}, New York, NY`;
+}
+
+/** Appends ", New York, NY" unless the text already names New York / NY. */
+function withCitySuffix(text) {
+    return /new york|,\s*ny\b/i.test(text) ? text : `${text}, New York, NY`;
+}
+
+/**
+ * Ordered Nominatim query candidates for a pop-up, most to least precise:
+ * the street address, an intersection-friendly "&" → "and" variant, then the
+ * venue name alone as a landmark lookup (catches parks, plazas, and stores
+ * whose address text Nominatim can't parse).
+ */
+function buildGeocodeQueries(venueName, address) {
+    const venue = (venueName || '').trim();
+    const addr = (address || '').trim();
+    const queries = [];
+    if (addr) {
+        queries.push(withCitySuffix(addr));
+        if (addr.includes('&')) {
+            queries.push(withCitySuffix(addr.replace(/\s*&\s*/g, ' and ')));
+        }
+    }
+    if (venue) {
+        queries.push(withCitySuffix(venue));
+    }
+    return [...new Set(queries)];
 }
 
 function loadCache() {
@@ -238,25 +265,34 @@ function sleep(ms) {
 }
 
 /**
- * Resolves coordinates for a cache key, geocoding via Nominatim on a cache
- * miss. Throttles after every real network attempt — success or failure —
- * so a failing address can't skip the 1 req/sec delay before the next call.
+ * Resolves coordinates for a cache key, trying each candidate query against
+ * Nominatim until one matches. Cached coordinates are trusted, but a cached
+ * null miss is retried — addresses get fixed and the query strategy improves,
+ * so misses must not be permanent. Throttles after every real network attempt
+ * — success or failure — so a failing address can't skip the 1 req/sec delay
+ * before the next call.
  */
-async function resolveCoordinates(key, cache, deps = {}) {
+async function resolveCoordinates(key, queries, cache, deps = {}) {
     const geocode = deps.geocode || geocodeAddress;
     const wait = deps.sleep || sleep;
 
-    if (Object.prototype.hasOwnProperty.call(cache, key)) {
+    if (cache[key]) {
         return { coords: cache[key], cacheDirty: false };
     }
 
-    try {
-        const coords = await geocode(key);
-        cache[key] = coords;
-        return { coords, cacheDirty: true };
-    } finally {
-        await wait(NOMINATIM_THROTTLE_MS);
+    const hadCachedMiss = Object.prototype.hasOwnProperty.call(cache, key);
+    let coords = null;
+    for (const query of queries) {
+        try {
+            coords = await geocode(query);
+        } finally {
+            await wait(NOMINATIM_THROTTLE_MS);
+        }
+        if (coords) break;
     }
+
+    cache[key] = coords;
+    return { coords, cacheDirty: !(hadCachedMiss && coords === null) };
 }
 
 // ---------------------------------------------------------------------------
@@ -291,14 +327,15 @@ async function main() {
 
     for (const popup of popups) {
         const key = normalizeAddressKey(popup.venue_name, popup.address);
-        if (!key) {
+        const queries = buildGeocodeQueries(popup.venue_name, popup.address);
+        if (!key || queries.length === 0) {
             skipped++;
             continue;
         }
 
         let coords;
         try {
-            const result = await resolveCoordinates(key, cache);
+            const result = await resolveCoordinates(key, queries, cache);
             coords = result.coords;
             if (result.cacheDirty) cacheDirty = true;
         } catch (err) {
@@ -351,4 +388,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { normalizeAddressKey, geocodeAddress, sanityFetch, sanityMutate, parseMutateResponse, loadCache, saveCache, resolveCoordinates };
+module.exports = { normalizeAddressKey, buildGeocodeQueries, geocodeAddress, sanityFetch, sanityMutate, parseMutateResponse, loadCache, saveCache, resolveCoordinates };

--- a/tests/unit/geocode-popups.spec.js
+++ b/tests/unit/geocode-popups.spec.js
@@ -1,5 +1,6 @@
 const {
   normalizeAddressKey,
+  buildGeocodeQueries,
   resolveCoordinates,
   parseMutateResponse,
 } = require('../../scripts/geocode-popups.js')
@@ -17,6 +18,37 @@ describe('normalizeAddressKey', () => {
   })
 })
 
+describe('buildGeocodeQueries', () => {
+  it('tries the bare address first, then the venue as a landmark', () => {
+    expect(buildGeocodeQueries('Remedy Diner', '245 E Houston St')).toEqual([
+      '245 E Houston St, New York, NY',
+      'Remedy Diner, New York, NY',
+    ])
+  })
+
+  it('does not duplicate the city suffix when the address already includes NY', () => {
+    expect(buildGeocodeQueries('22 Wooster', '22 Wooster St, New York, NY 10013')).toEqual([
+      '22 Wooster St, New York, NY 10013',
+      '22 Wooster, New York, NY',
+    ])
+  })
+
+  it('adds an intersection variant with "and" when the address contains an ampersand', () => {
+    expect(
+      buildGeocodeQueries('Chelsea Triangle', 'W 14th St & 9th Ave, New York, NY 10014')
+    ).toEqual([
+      'W 14th St & 9th Ave, New York, NY 10014',
+      'W 14th St and 9th Ave, New York, NY 10014',
+      'Chelsea Triangle, New York, NY',
+    ])
+  })
+
+  it('drops blank parts and returns no queries when everything is blank', () => {
+    expect(buildGeocodeQueries('Domino Park', '')).toEqual(['Domino Park, New York, NY'])
+    expect(buildGeocodeQueries('', '')).toEqual([])
+  })
+})
+
 describe('resolveCoordinates', () => {
   it('throttles after a failed geocode attempt just like after a successful one', async () => {
     const cache = {}
@@ -31,11 +63,11 @@ describe('resolveCoordinates', () => {
       .mockResolvedValueOnce({ lat: 1, lon: 2 })
 
     await expect(
-      resolveCoordinates('addr-1', cache, { geocode, sleep })
+      resolveCoordinates('addr-1', ['query 1'], cache, { geocode, sleep })
     ).rejects.toThrow('boom')
     expect(sleepCalls).toHaveLength(1)
 
-    const result = await resolveCoordinates('addr-2', cache, { geocode, sleep })
+    const result = await resolveCoordinates('addr-2', ['query 2'], cache, { geocode, sleep })
     expect(result).toEqual({ coords: { lat: 1, lon: 2 }, cacheDirty: true })
     expect(sleepCalls).toHaveLength(2)
   })
@@ -45,7 +77,7 @@ describe('resolveCoordinates', () => {
     const geocode = vi.fn()
     const sleep = vi.fn()
 
-    const result = await resolveCoordinates('addr-1', cache, { geocode, sleep })
+    const result = await resolveCoordinates('addr-1', ['query 1'], cache, { geocode, sleep })
 
     expect(result).toEqual({ coords: { lat: 1, lon: 2 }, cacheDirty: false })
     expect(geocode).not.toHaveBeenCalled()
@@ -58,9 +90,63 @@ describe('resolveCoordinates', () => {
     const sleep = vi.fn().mockResolvedValue(undefined)
 
     await expect(
-      resolveCoordinates('addr-1', cache, { geocode, sleep })
+      resolveCoordinates('addr-1', ['query 1'], cache, { geocode, sleep })
     ).rejects.toThrow('network error')
     expect(cache).not.toHaveProperty('addr-1')
+  })
+
+  it('falls through the query chain until one matches, throttling each attempt', async () => {
+    const cache = {}
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const geocode = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ lat: 40.7, lon: -74.0 })
+
+    const result = await resolveCoordinates(
+      'addr-1',
+      ['query 1', 'query 2', 'query 3'],
+      cache,
+      { geocode, sleep }
+    )
+
+    expect(geocode.mock.calls.map(c => c[0])).toEqual(['query 1', 'query 2', 'query 3'])
+    expect(result).toEqual({ coords: { lat: 40.7, lon: -74.0 }, cacheDirty: true })
+    expect(cache['addr-1']).toEqual({ lat: 40.7, lon: -74.0 })
+    expect(sleep).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops at the first query that matches without trying the rest', async () => {
+    const cache = {}
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const geocode = vi.fn().mockResolvedValue({ lat: 1, lon: 2 })
+
+    await resolveCoordinates('addr-1', ['query 1', 'query 2'], cache, { geocode, sleep })
+
+    expect(geocode).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a cached null miss instead of treating it as permanent', async () => {
+    const cache = { 'addr-1': null }
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const geocode = vi.fn().mockResolvedValue({ lat: 3, lon: 4 })
+
+    const result = await resolveCoordinates('addr-1', ['query 1'], cache, { geocode, sleep })
+
+    expect(geocode).toHaveBeenCalled()
+    expect(result).toEqual({ coords: { lat: 3, lon: 4 }, cacheDirty: true })
+    expect(cache['addr-1']).toEqual({ lat: 3, lon: 4 })
+  })
+
+  it('reports a clean cache when a retried miss is still a miss', async () => {
+    const cache = { 'addr-1': null }
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const geocode = vi.fn().mockResolvedValue(null)
+
+    const result = await resolveCoordinates('addr-1', ['query 1'], cache, { geocode, sleep })
+
+    expect(result).toEqual({ coords: null, cacheDirty: false })
   })
 })
 


### PR DESCRIPTION
The geocoder assumed bare street addresses and built Nominatim queries as `venue, address, New York, NY`. The #286 backfill writes full addresses (city/state/zip included), so 6 of 7 active pop-ups produced unparseable queries and were skipped — with the misses cached as permanent nulls.

**Fix** (written test-first, 100/100 unit tests pass):
- `buildGeocodeQueries()` produces an ordered fallback chain: bare address (city suffix appended only when missing) → `&` → `and` intersection variant → venue name as a landmark lookup.
- `resolveCoordinates()` tries the chain until a match, still throttling every attempt per Nominatim policy.
- Cached null misses are now retried instead of being permanent; cached coordinates and cache keys are unchanged.
- Includes the refreshed `data/geocode-cache.json`: a live dry-run geocoded all 6 previously-failing pop-ups to correct NYC coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)