### PR TITLE
Add shared search bar and List/Map view toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ node_modules/
 playwright-report/
 test-results/
 .lighthouseci/
+
+# Local Claude Code tooling
+.claude/

--- a/date-ideas.html
+++ b/date-ideas.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="resources/css/header.css">
     <link rel="stylesheet" href="resources/css/hero.css">
     <link rel="stylesheet" href="resources/css/buttons.css">
+    <link rel="stylesheet" href="resources/css/search.css">
     <link rel="stylesheet" href="resources/css/popups.css">
   <link rel="stylesheet" href="resources/css/date_ideas.css">
     <link rel="stylesheet" href="resources/css/popup_details.css">
@@ -26,6 +27,7 @@
     <script src="resources/js/sanity-client.js" defer></script>
     <script src="resources/js/sanity-queries.js" defer></script>
     <script src="resources/js/date-ideas.js" defer></script>
+    <script src="resources/js/search.js" defer></script>
     <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
   </head>
   <body>
@@ -44,6 +46,17 @@
           <p>Discover creative, fun, and unique things to do in NYC at any time!</p>
         </div>
       </section>
+
+      <!-- Search (redesign only; no map view for date ideas) -->
+      <div class="search-bar-container">
+        <div class="search-bar">
+          <svg class="search-bar__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="16.5" y1="16.5" x2="21" y2="21"></line>
+          </svg>
+          <input class="ui-input search-bar__input" type="search" placeholder="Search events, venues, neighborhoods..." aria-label="Search events, venues, and neighborhoods">
+        </div>
+      </div>
 
       <!-- Date Ideas Tiles Grid -->
       <section class="date-ideas-grid" id="dateIdeasGrid">

--- a/pop-ups.html
+++ b/pop-ups.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="resources/css/header.css">
     <link rel="stylesheet" href="resources/css/hero.css">
     <link rel="stylesheet" href="resources/css/buttons.css">
+    <link rel="stylesheet" href="resources/css/search.css">
     <link rel="stylesheet" href="resources/css/popups.css">
     <link rel="stylesheet" href="resources/css/footer.css">
     <!-- Removed broken style.css link -->
@@ -27,6 +28,7 @@
         <script src="resources/js/partials-loader.js" defer></script>
         <script src="resources/js/sanity-client.js" defer></script>
         <script src="resources/js/sanity-queries.js" defer></script>
+        <script src="resources/js/search.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
         <!-- STATIC_JSONLD_START -->
         <!-- STATIC_JSONLD_END -->
@@ -47,6 +49,21 @@
                     <p>Discover upcoming pop-ups and citywide experiences.</p>
                 </div>
             </section>
+
+            <!-- Search + view toggle (redesign only) -->
+            <div class="search-bar-container">
+                <div class="search-bar">
+                    <svg class="search-bar__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+                        <circle cx="11" cy="11" r="7"></circle>
+                        <line x1="16.5" y1="16.5" x2="21" y2="21"></line>
+                    </svg>
+                    <input class="ui-input search-bar__input" type="search" placeholder="Search events, venues, neighborhoods..." aria-label="Search events, venues, and neighborhoods">
+                </div>
+                <div class="view-toggle" role="group" aria-label="View mode">
+                    <button type="button" class="view-toggle__btn view-toggle__btn--active" data-view="list" aria-pressed="true">List</button>
+                    <button type="button" class="view-toggle__btn" data-view="map" aria-pressed="false">Map</button>
+                </div>
+            </div>
 
             <!-- Pop-up Tiles Grid -->
             <section class="popups-grid" id="popupsGrid">

--- a/resources/css/search.css
+++ b/resources/css/search.css
@@ -7,6 +7,10 @@
   display: none;
 }
 
+/* Constrained to --container-max-width per REDESIGN.md 6.2. The legacy
+   .popup-tile still centers itself inside a 950px cap, so the two do not
+   line up yet; that resolves in #291 when .event-card replaces the tile and
+   adopts the same container width. */
 :root[data-redesign='on'] .search-bar-container,
 body.redesign-enabled .search-bar-container {
   display: flex;
@@ -37,7 +41,8 @@ body.redesign-enabled .search-bar__icon {
 
 :root[data-redesign='on'] .search-bar__input,
 body.redesign-enabled .search-bar__input {
-  padding-left: 44px;
+  min-height: 44px;
+  padding: 12px var(--space-sm) 12px 44px;
   background-color: var(--nyc-white);
   font-size: var(--font-sm);
 }
@@ -52,6 +57,7 @@ body.redesign-enabled .view-toggle {
 
 :root[data-redesign='on'] .view-toggle__btn,
 body.redesign-enabled .view-toggle__btn {
+  min-height: 44px;
   padding: 10px var(--space-sm);
   border: 1px solid var(--nyc-medium-gray);
   border-radius: var(--radius-md);
@@ -88,6 +94,13 @@ body.redesign-enabled .search-bar__input:focus-visible {
   :root[data-redesign='on'] .search-bar,
   body.redesign-enabled .search-bar {
     flex-basis: 100%;
+  }
+
+  /* The toggle wraps to its own row, so stretch it before splitting the
+     buttons across it. */
+  :root[data-redesign='on'] .view-toggle,
+  body.redesign-enabled .view-toggle {
+    flex: 1 0 100%;
   }
 
   :root[data-redesign='on'] .view-toggle__btn,

--- a/resources/css/search.css
+++ b/resources/css/search.css
@@ -1,0 +1,97 @@
+/* -----------------------------------------------------------------------------
+  SEARCH BAR + VIEW TOGGLE (redesign only)
+  Hidden by default so flag-off pages are unchanged; the layout is scoped to
+  the redesign flag. See REDESIGN.md section 6.2.
+----------------------------------------------------------------------------- */
+.search-bar-container {
+  display: none;
+}
+
+:root[data-redesign='on'] .search-bar-container,
+body.redesign-enabled .search-bar-container {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  max-width: var(--container-max-width);
+  margin-inline: auto;
+  padding: var(--space-sm-md) var(--space-sm-md) 0;
+}
+
+:root[data-redesign='on'] .search-bar,
+body.redesign-enabled .search-bar {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+:root[data-redesign='on'] .search-bar__icon,
+body.redesign-enabled .search-bar__icon {
+  position: absolute;
+  left: var(--space-sm);
+  width: 18px;
+  height: 18px;
+  color: var(--nyc-medium-gray);
+  pointer-events: none;
+}
+
+:root[data-redesign='on'] .search-bar__input,
+body.redesign-enabled .search-bar__input {
+  padding-left: 44px;
+  background-color: var(--nyc-white);
+  font-size: var(--font-sm);
+}
+
+/* View toggle -------------------------------------------------------------- */
+
+:root[data-redesign='on'] .view-toggle,
+body.redesign-enabled .view-toggle {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+:root[data-redesign='on'] .view-toggle__btn,
+body.redesign-enabled .view-toggle__btn {
+  padding: 10px var(--space-sm);
+  border: 1px solid var(--nyc-medium-gray);
+  border-radius: var(--radius-md);
+  background-color: var(--nyc-white);
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .view-toggle__btn--active,
+body.redesign-enabled .view-toggle__btn--active {
+  border-color: var(--nyc-green);
+  background-color: var(--nyc-green);
+  color: var(--nyc-white);
+}
+
+:root[data-redesign='on'] .view-toggle__btn:focus-visible,
+:root[data-redesign='on'] .search-bar__input:focus-visible,
+body.redesign-enabled .view-toggle__btn:focus-visible,
+body.redesign-enabled .search-bar__input:focus-visible {
+  outline: 2px solid var(--nyc-green);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  :root[data-redesign='on'] .search-bar-container,
+  body.redesign-enabled .search-bar-container {
+    flex-wrap: wrap;
+    padding: var(--space-sm) var(--space-sm) 0;
+  }
+
+  :root[data-redesign='on'] .search-bar,
+  body.redesign-enabled .search-bar {
+    flex-basis: 100%;
+  }
+
+  :root[data-redesign='on'] .view-toggle__btn,
+  body.redesign-enabled .view-toggle__btn {
+    flex: 1;
+  }
+}

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -51,6 +51,14 @@ function normalizeSearchInput(value) {
 // === DOM WIRING ===
 
 /**
+ * Reflects the active view on the document root so CSS and view code can key
+ * off it, keeping the toggle's announced state tied to real page state.
+ */
+function reflectView(doc, view) {
+    if (doc.documentElement) doc.documentElement.setAttribute('data-view', view);
+}
+
+/**
  * Wires the view toggle and search input within the given document. Emits
  * `viewtoggle:change` and `search:change` so filtering/map code can react
  * without this module knowing about them.
@@ -69,6 +77,7 @@ function initSearchBar(doc) {
             if (!next.changed) return;
             currentView = next.view;
             applyToggleState(buttons, currentView);
+            reflectView(doc, currentView);
             container.dispatchEvent(
                 new CustomEvent('viewtoggle:change', {
                     bubbles: true,
@@ -78,7 +87,10 @@ function initSearchBar(doc) {
         });
     });
 
-    if (buttons.length > 0) applyToggleState(buttons, currentView);
+    if (buttons.length > 0) {
+        applyToggleState(buttons, currentView);
+        reflectView(doc, currentView);
+    }
 
     if (input) {
         input.addEventListener('input', () => {

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -1,0 +1,115 @@
+// Shared search bar and List/Map view toggle for the redesigned discovery
+// pages. Behaviour is gated on the redesign flag; data filtering lives
+// elsewhere (see REDESIGN.md section 6.2).
+
+// === CONSTANTS ===
+
+/** View modes offered by the toggle, in display order. */
+const VIEWS = ['list', 'map'];
+
+const ACTIVE_BUTTON_CLASS = 'view-toggle__btn--active';
+
+// === PURE HELPERS ===
+
+function isValidView(view) {
+    return VIEWS.includes(view);
+}
+
+/**
+ * Resolves the toggle's next state. Requesting the active view, or an unknown
+ * view, leaves the current view untouched.
+ * @returns {{view: string, changed: boolean}}
+ */
+function getNextToggleState(currentView, requestedView) {
+    if (!isValidView(requestedView) || requestedView === currentView) {
+        return { view: currentView, changed: false };
+    }
+    return { view: requestedView, changed: true };
+}
+
+/** Reflects the active view onto the toggle buttons (class + aria-pressed). */
+function applyToggleState(buttons, activeView) {
+    buttons.forEach(button => {
+        const isActive = button.dataset.view === activeView;
+        if (isActive) {
+            button.classList.add(ACTIVE_BUTTON_CLASS);
+        } else {
+            button.classList.remove(ACTIVE_BUTTON_CLASS);
+        }
+        button.setAttribute('aria-pressed', String(isActive));
+    });
+}
+
+/** Normalizes a raw search query for case-insensitive matching later. */
+function normalizeSearchInput(value) {
+    return String(value == null ? '' : value)
+        .trim()
+        .replace(/\s+/g, ' ')
+        .toLowerCase();
+}
+
+// === DOM WIRING ===
+
+/**
+ * Wires the view toggle and search input within the given document. Emits
+ * `viewtoggle:change` and `search:change` so filtering/map code can react
+ * without this module knowing about them.
+ */
+function initSearchBar(doc) {
+    const container = doc.querySelector('.search-bar-container');
+    if (!container) return null;
+
+    const buttons = Array.from(container.querySelectorAll('.view-toggle__btn'));
+    const input = container.querySelector('.search-bar__input');
+    let currentView = VIEWS[0];
+
+    buttons.forEach(button => {
+        button.addEventListener('click', () => {
+            const next = getNextToggleState(currentView, button.dataset.view);
+            if (!next.changed) return;
+            currentView = next.view;
+            applyToggleState(buttons, currentView);
+            container.dispatchEvent(
+                new CustomEvent('viewtoggle:change', {
+                    bubbles: true,
+                    detail: { view: currentView },
+                })
+            );
+        });
+    });
+
+    if (buttons.length > 0) applyToggleState(buttons, currentView);
+
+    if (input) {
+        input.addEventListener('input', () => {
+            container.dispatchEvent(
+                new CustomEvent('search:change', {
+                    bubbles: true,
+                    detail: { query: normalizeSearchInput(input.value) },
+                })
+            );
+        });
+    }
+
+    return { getView: () => currentView };
+}
+
+// === BOOTSTRAP ===
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.REDESIGN_FLAG || !window.REDESIGN_FLAG.isEnabled()) return;
+        initSearchBar(document);
+    });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        VIEWS,
+        isValidView,
+        getNextToggleState,
+        applyToggleState,
+        normalizeSearchInput,
+        initSearchBar,
+    };
+}

--- a/tests/e2e/redesign-search.spec.js
+++ b/tests/e2e/redesign-search.spec.js
@@ -49,6 +49,79 @@ test('search controls stay hidden when the redesign flag is off', async ({ page 
   await expect(page.getByRole('button', { name: 'Map' })).toBeHidden()
 })
 
+test('search bar stays within the shared container width and stays centered', async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const { containerBox, maxWidth, viewportWidth } = await page.evaluate(() => {
+    const container = document.querySelector('.search-bar-container')
+    const rect = container.getBoundingClientRect()
+    return {
+      containerBox: { left: rect.left, width: rect.width },
+      maxWidth: parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--container-max-width')
+      ),
+      viewportWidth: window.innerWidth,
+    }
+  })
+
+  expect(containerBox.width).toBeLessThanOrEqual(maxWidth)
+  // Equal gutters either side.
+  const rightGutter = viewportWidth - (containerBox.left + containerBox.width)
+  expect(Math.abs(containerBox.left - rightGutter)).toBeLessThanOrEqual(1)
+})
+
+test('search input and toggle buttons meet the 44px touch target on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const heights = await page.evaluate(() => ({
+    input: document.querySelector('.search-bar__input').getBoundingClientRect().height,
+    button: document.querySelector('.view-toggle__btn').getBoundingClientRect().height,
+  }))
+
+  expect(heights.input).toBeGreaterThanOrEqual(44)
+  expect(heights.button).toBeGreaterThanOrEqual(44)
+})
+
+test('toggle buttons share the full row width on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  // The toggle wraps onto its own row below the input, so it should span that
+  // row rather than shrink-wrapping its labels.
+  const { rowWidth, toggleWidth, buttonWidths } = await page.evaluate(() => {
+    const container = document.querySelector('.search-bar-container')
+    const styles = getComputedStyle(container)
+    const rowWidth =
+      container.getBoundingClientRect().width -
+      parseFloat(styles.paddingLeft) -
+      parseFloat(styles.paddingRight)
+    return {
+      rowWidth,
+      toggleWidth: document.querySelector('.view-toggle').getBoundingClientRect().width,
+      buttonWidths: [...document.querySelectorAll('.view-toggle__btn')].map(
+        (b) => b.getBoundingClientRect().width
+      ),
+    }
+  })
+
+  expect(toggleWidth).toBeGreaterThan(rowWidth * 0.95)
+  for (const width of buttonWidths) {
+    expect(width).toBeGreaterThan(rowWidth * 0.4)
+  }
+})
+
+test('selecting a view reflects it as page state for view code to consume', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(page.locator('html')).toHaveAttribute('data-view', 'list')
+
+  await page.getByRole('button', { name: 'Map' }).click()
+
+  await expect(page.locator('html')).toHaveAttribute('data-view', 'map')
+})
+
 test('search bar wraps without horizontal overflow on a small phone', async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 })
   await page.goto('/pop-ups.html?redesign=on')

--- a/tests/e2e/redesign-search.spec.js
+++ b/tests/e2e/redesign-search.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test')
+
+test('search bar and view toggle appear when the redesign flag is on', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(page.getByRole('searchbox', { name: /search events, venues, and neighborhoods/i })).toBeVisible()
+  await expect(page.getByRole('group', { name: /view mode/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByRole('button', { name: 'Map' })).toHaveAttribute('aria-pressed', 'false')
+})
+
+test('clicking Map moves the active state and emits a view change', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const received = page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        document.addEventListener('viewtoggle:change', (event) => resolve(event.detail.view), { once: true })
+      })
+  )
+
+  await page.getByRole('button', { name: 'Map' }).click()
+
+  await expect(page.getByRole('button', { name: 'Map' })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'false')
+  expect(await received).toBe('map')
+})
+
+test('the toggle is keyboard operable', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await page.getByRole('button', { name: 'Map' }).focus()
+  await page.keyboard.press('Enter')
+
+  await expect(page.getByRole('button', { name: 'Map' })).toHaveAttribute('aria-pressed', 'true')
+})
+
+test('date ideas gets the search bar but no view toggle', async ({ page }) => {
+  await page.goto('/date-ideas.html?redesign=on')
+
+  await expect(page.getByRole('searchbox', { name: /search events, venues, and neighborhoods/i })).toBeVisible()
+  await expect(page.getByRole('group', { name: /view mode/i })).toHaveCount(0)
+})
+
+test('search controls stay hidden when the redesign flag is off', async ({ page }) => {
+  await page.goto('/pop-ups.html')
+
+  await expect(page.locator('.search-bar-container')).toBeHidden()
+  await expect(page.getByRole('button', { name: 'Map' })).toBeHidden()
+})
+
+test('search bar wraps without horizontal overflow on a small phone', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(page.getByRole('searchbox', { name: /search events/i })).toBeVisible()
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow).toBe(0)
+})

--- a/tests/unit/search-components.spec.js
+++ b/tests/unit/search-components.spec.js
@@ -1,0 +1,146 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  VIEWS,
+  isValidView,
+  getNextToggleState,
+  applyToggleState,
+  normalizeSearchInput,
+} = require('../../resources/js/search.js')
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+function expectCssToMatch(css, pattern) {
+  const regexSpecialCharacters = new Set(['\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'])
+  const escapedPattern = [...pattern]
+    .map((character) => (regexSpecialCharacters.has(character) ? `\\${character}` : character))
+    .join('')
+  expect(css).toMatch(new RegExp(escapedPattern.replaceAll(/\s+/g, '\\s*')))
+}
+
+/** Minimal stand-in for a toggle button element. */
+function createButtonStub(view, active) {
+  const classes = new Set(['view-toggle__btn'])
+  if (active) classes.add('view-toggle__btn--active')
+  const attributes = new Map([['aria-pressed', String(Boolean(active))]])
+  return {
+    dataset: { view },
+    classList: {
+      add: (name) => classes.add(name),
+      remove: (name) => classes.delete(name),
+      contains: (name) => classes.has(name),
+    },
+    setAttribute: (name, value) => attributes.set(name, String(value)),
+    getAttribute: (name) => (attributes.has(name) ? attributes.get(name) : null),
+  }
+}
+
+describe('view toggle state', () => {
+  it('exposes the two views specified by the redesign', () => {
+    expect(VIEWS).toEqual(['list', 'map'])
+  })
+
+  it('accepts only known view names', () => {
+    expect(isValidView('list')).toBe(true)
+    expect(isValidView('map')).toBe(true)
+    expect(isValidView('calendar')).toBe(false)
+    expect(isValidView(undefined)).toBe(false)
+  })
+
+  it('switches to the requested view and reports the change', () => {
+    expect(getNextToggleState('list', 'map')).toEqual({ view: 'map', changed: true })
+  })
+
+  it('is a no-op when the active view is requested again', () => {
+    expect(getNextToggleState('map', 'map')).toEqual({ view: 'map', changed: false })
+  })
+
+  it('ignores unknown view names and keeps the current view', () => {
+    expect(getNextToggleState('list', 'calendar')).toEqual({ view: 'list', changed: false })
+  })
+
+  it('applies the active class and aria-pressed to the selected button only', () => {
+    const listButton = createButtonStub('list', true)
+    const mapButton = createButtonStub('map', false)
+
+    applyToggleState([listButton, mapButton], 'map')
+
+    expect(mapButton.classList.contains('view-toggle__btn--active')).toBe(true)
+    expect(mapButton.getAttribute('aria-pressed')).toBe('true')
+    expect(listButton.classList.contains('view-toggle__btn--active')).toBe(false)
+    expect(listButton.getAttribute('aria-pressed')).toBe('false')
+  })
+})
+
+describe('normalizeSearchInput', () => {
+  it('trims and collapses whitespace and lowercases for matching', () => {
+    expect(normalizeSearchInput('  Chelsea   Market ')).toBe('chelsea market')
+  })
+
+  it('returns an empty string for blank or missing values', () => {
+    expect(normalizeSearchInput('   ')).toBe('')
+    expect(normalizeSearchInput(undefined)).toBe('')
+  })
+})
+
+describe('search and view-toggle styles', () => {
+  const css = read('resources/css/search.css')
+
+  it('hides the search container by default so the flag-off page is unchanged', () => {
+    expectCssToMatch(css, '.search-bar-container { display: none; }')
+  })
+
+  it('gates the layout behind the redesign flag scope', () => {
+    expectCssToMatch(css, ":root[data-redesign='on'] .search-bar-container")
+    expectCssToMatch(css, 'body.redesign-enabled .search-bar-container')
+  })
+
+  it('lays the container out per the redesign spec', () => {
+    expectCssToMatch(css, 'display: flex;')
+    expectCssToMatch(css, 'gap: 12px;')
+  })
+
+  it('styles the active toggle button with the redesign green', () => {
+    expectCssToMatch(css, 'background-color: var(--nyc-green);')
+    expectCssToMatch(css, 'color: var(--nyc-white);')
+  })
+})
+
+describe('search and view-toggle markup', () => {
+  const popupsHtml = read('pop-ups.html')
+  const dateIdeasHtml = read('date-ideas.html')
+
+  it('adds the search bar to both discovery pages', () => {
+    for (const html of [popupsHtml, dateIdeasHtml]) {
+      expect(html).toContain('class="search-bar-container"')
+      expect(html).toContain('placeholder="Search events, venues, neighborhoods..."')
+      expect(html).toContain('type="search"')
+    }
+  })
+
+  it('renders the List/Map toggle on pop-ups only', () => {
+    expect(popupsHtml).toContain('class="view-toggle"')
+    expect(popupsHtml).toContain('data-view="list"')
+    expect(popupsHtml).toContain('data-view="map"')
+    expect(popupsHtml).not.toContain('data-view="calendar"')
+    expect(dateIdeasHtml).not.toContain('class="view-toggle"')
+  })
+
+  it('labels the toggle group and the search input for assistive tech', () => {
+    expect(popupsHtml).toContain('role="group"')
+    expect(popupsHtml).toMatch(/aria-label="View mode"/)
+    expect(popupsHtml).toMatch(/aria-label="Search events, venues, and neighborhoods"/)
+  })
+
+  it('links the search stylesheet and script on both pages', () => {
+    for (const html of [popupsHtml, dateIdeasHtml]) {
+      expect(html).toContain('<link rel="stylesheet" href="resources/css/search.css">')
+      expect(html).toContain('<script src="resources/js/search.js" defer></script>')
+    }
+  })
+})


### PR DESCRIPTION
Implements #288 (Epic 3: shared redesign components).

## What changed
- **`resources/css/search.css`** (new): pill search input with an inline magnifier and a two-button List/Map toggle per REDESIGN.md §6.2 — 12px gap container centered at `--container-max-width`, active button `--nyc-green` on white text, inactive white on `--nyc-navy`, `--radius-md` corners, plus `:focus-visible` rings. At ≤600px the container wraps and the toggle buttons split the row.
- **`resources/js/search.js`** (new): pure helpers `getNextToggleState`, `applyToggleState`, `normalizeSearchInput`, `isValidView`, and a flag-gated `initSearchBar`. Emits `viewtoggle:change` and `search:change` CustomEvents so the map (#294) and filters (#289) can subscribe without coupling. **Data filtering is out of scope** per the issue.
- **Markup**: pop-ups gets search + toggle; date ideas gets search only (§7.2 — no map view there). Both pages link the new stylesheet and script.
- **`.gitignore`**: ignore `.claude/` local tooling.

## Gating
Same pattern as the hero: `.search-bar-container` is `display: none` unscoped and only laid out under `:root[data-redesign='on'] / body.redesign-enabled`; the JS bootstrap returns early unless `window.REDESIGN_FLAG.isEnabled()`. Flag-off pages are unchanged and the controls stay out of the a11y tree, so Lighthouse (which audits flag-off) is unaffected.

## Scope note
The issue text mentions a List/Map/**Calendar** toggle, but REDESIGN.md §6.2 specifies only List/Map, and §7.2 drops the toggle entirely for date ideas. Built to the spec — the Calendar view belongs to Epic 5 ("Calendar integration into Pop-Ups"), and `isValidView` will reject an unknown `calendar` value until it's deliberately added.

Toggle logic lives in `search.js` rather than `filters.js` (which §7.1 loosely suggests) to keep this PR self-contained and let date ideas load search without pulling in filter code.

## Accessibility
`role="group"` + `aria-label="View mode"` on the toggle, `aria-pressed` maintained on both buttons, labelled `type="search"` input, decorative SVG marked `aria-hidden`, and visible focus rings. Keyboard operation is covered by an e2e test.

## Tests
Written test-first — 16 unit assertions (state machine, normalization, CSS, markup, asset links) and 6 e2e (visible flag-on, click flips `aria-pressed`, Enter-key operation, emitted event payload, date-ideas has no toggle, flag-off hidden, no horizontal overflow at 375px). Full suite: **127 unit + 23 e2e pass**; stylelint and HTMLHint clean. Verified in-browser at desktop and mobile with `?redesign=on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)