### PR TITLE
Add shared filter bar, chips and dropdowns

### DIFF
--- a/date-ideas.html
+++ b/date-ideas.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="resources/css/hero.css">
     <link rel="stylesheet" href="resources/css/buttons.css">
     <link rel="stylesheet" href="resources/css/search.css">
+    <link rel="stylesheet" href="resources/css/filters.css">
     <link rel="stylesheet" href="resources/css/popups.css">
   <link rel="stylesheet" href="resources/css/date_ideas.css">
     <link rel="stylesheet" href="resources/css/popup_details.css">
@@ -28,6 +29,7 @@
     <script src="resources/js/sanity-queries.js" defer></script>
     <script src="resources/js/date-ideas.js" defer></script>
     <script src="resources/js/search.js" defer></script>
+    <script src="resources/js/filters.js" defer></script>
     <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
   </head>
   <body>
@@ -57,6 +59,53 @@
           <input class="ui-input search-bar__input" type="search" placeholder="Search events, venues, neighborhoods..." aria-label="Search events, venues, and neighborhoods">
         </div>
       </div>
+
+      <!-- Filter bar (redesign only) -->
+      <div class="filter-bar" role="toolbar" aria-label="Filter date ideas" data-filter-page="date-ideas">
+        <div class="filter-bar__group">
+          <button type="button" class="ui-filter-chip filter-chip" data-filter="vibe" data-label="Vibe" aria-haspopup="listbox" aria-expanded="false">
+            <span class="filter-chip__label">Vibe</span>
+            <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+          </button>
+          <ul class="filter-dropdown" role="listbox" aria-label="Vibe" hidden>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="romantic" data-label="Romantic">&#127801; Romantic</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="adventurous" data-label="Adventurous">&#129517; Adventurous</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="chill" data-label="Chill">&#127810; Chill</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="foodie" data-label="Foodie">&#127860; Foodie</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="cultural" data-label="Cultural">&#127914; Cultural</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="free" data-label="Free">&#10024; Free</li>
+          </ul>
+        </div>
+        <div class="filter-bar__group">
+          <button type="button" class="ui-filter-chip filter-chip" data-filter="budget" data-label="Budget" aria-haspopup="listbox" aria-expanded="false">
+            <span class="filter-chip__label">Budget</span>
+            <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+          </button>
+          <ul class="filter-dropdown" role="listbox" aria-label="Budget" hidden>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="free" data-label="Free">Free</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="under_30" data-label="Under $30">Under $30</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="30_to_75" data-label="$30&#8211;$75">$30&#8211;$75</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="75_plus" data-label="$75+">$75+</li>
+          </ul>
+        </div>
+        <div class="filter-bar__group">
+          <button type="button" class="ui-filter-chip filter-chip" data-filter="neighborhood" data-label="Neighborhood" aria-haspopup="listbox" aria-expanded="false">
+            <span class="filter-chip__label">Neighborhood</span>
+            <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+          </button>
+          <ul class="filter-dropdown" role="listbox" aria-label="Neighborhood" hidden>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Corona" data-label="Corona">Corona</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Fordham" data-label="Fordham">Fordham</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Lincoln Square" data-label="Lincoln Square">Lincoln Square</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Meatpacking District" data-label="Meatpacking District">Meatpacking District</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Midtown" data-label="Midtown">Midtown</li>
+            <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Washington Heights" data-label="Washington Heights">Washington Heights</li>
+          </ul>
+        </div>
+        <button type="button" class="ui-btn--text filter-bar__clear" hidden>&#215; Clear all</button>
+      </div>
+      <p class="results-count" aria-live="polite">0 date ideas found</p>
+      <hr class="ui-divider results-divider">
 
       <!-- Date Ideas Tiles Grid -->
       <section class="date-ideas-grid" id="dateIdeasGrid">

--- a/pop-ups.html
+++ b/pop-ups.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" href="resources/css/hero.css">
     <link rel="stylesheet" href="resources/css/buttons.css">
     <link rel="stylesheet" href="resources/css/search.css">
+    <link rel="stylesheet" href="resources/css/filters.css">
     <link rel="stylesheet" href="resources/css/popups.css">
     <link rel="stylesheet" href="resources/css/footer.css">
     <!-- Removed broken style.css link -->
@@ -29,6 +30,7 @@
         <script src="resources/js/sanity-client.js" defer></script>
         <script src="resources/js/sanity-queries.js" defer></script>
         <script src="resources/js/search.js" defer></script>
+        <script src="resources/js/filters.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
         <!-- STATIC_JSONLD_START -->
         <!-- STATIC_JSONLD_END -->
@@ -64,6 +66,64 @@
                     <button type="button" class="view-toggle__btn" data-view="map" aria-pressed="false">Map</button>
                 </div>
             </div>
+
+            <!-- Filter bar (redesign only) -->
+            <div class="filter-bar" role="toolbar" aria-label="Filter pop-ups" data-filter-page="popups">
+                <div class="filter-bar__group">
+                    <button type="button" class="ui-filter-chip filter-chip" data-filter="borough" data-label="Borough" aria-haspopup="listbox" aria-expanded="false">
+                        <span class="filter-chip__label">Borough</span>
+                        <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+                    </button>
+                    <ul class="filter-dropdown" role="listbox" aria-label="Borough" hidden>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="manhattan" data-label="Manhattan">Manhattan</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="brooklyn" data-label="Brooklyn">Brooklyn</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="queens" data-label="Queens">Queens</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="bronx" data-label="Bronx">Bronx</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="staten_island" data-label="Staten Island">Staten Island</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="citywide" data-label="Citywide">Citywide</li>
+                    </ul>
+                </div>
+                <div class="filter-bar__group">
+                    <button type="button" class="ui-filter-chip filter-chip" data-filter="neighborhood" data-label="Neighborhood" aria-haspopup="listbox" aria-expanded="false">
+                        <span class="filter-chip__label">Neighborhood</span>
+                        <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+                    </button>
+                    <ul class="filter-dropdown" role="listbox" aria-label="Neighborhood" hidden>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Chelsea" data-label="Chelsea">Chelsea</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="East Village" data-label="East Village">East Village</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Lower East Side" data-label="Lower East Side">Lower East Side</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="SoHo" data-label="SoHo">SoHo</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Williamsburg" data-label="Williamsburg">Williamsburg</li>
+                    </ul>
+                </div>
+                <div class="filter-bar__group">
+                    <button type="button" class="ui-filter-chip filter-chip" data-filter="type" data-label="Type" aria-haspopup="listbox" aria-expanded="false">
+                        <span class="filter-chip__label">Type</span>
+                        <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+                    </button>
+                    <ul class="filter-dropdown" role="listbox" aria-label="Type" hidden>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="food_drink" data-label="Food &amp; Drink">&#127829; Food &amp; Drink</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="market" data-label="Market">&#128717; Market</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="art_culture" data-label="Art &amp; Culture">&#127912; Art &amp; Culture</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="beauty" data-label="Beauty">&#128132; Beauty</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="fashion" data-label="Fashion">&#128087; Fashion</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="wellness" data-label="Wellness">&#129496; Wellness</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="music" data-label="Music">&#127925; Music</li>
+                        <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="vintage_thrift" data-label="Vintage &amp; Thrift">&#10024; Vintage &amp; Thrift</li>
+                    </ul>
+                </div>
+                <div class="filter-bar__group">
+                    <!-- Inert until the date picker lands (#290); disabled rather than
+                         announcing a menu it does not have yet. -->
+                    <button type="button" class="ui-filter-chip filter-chip" data-filter="dates" data-label="Pick dates" disabled>
+                        <span class="filter-chip__label">Pick dates</span>
+                        <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
+                    </button>
+                </div>
+                <button type="button" class="ui-btn--text filter-bar__clear" hidden>&#215; Clear all</button>
+            </div>
+            <p class="results-count" aria-live="polite">0 events found</p>
+            <hr class="ui-divider results-divider">
 
             <!-- Pop-up Tiles Grid -->
             <section class="popups-grid" id="popupsGrid">

--- a/resources/css/filters.css
+++ b/resources/css/filters.css
@@ -1,0 +1,181 @@
+/* -----------------------------------------------------------------------------
+  FILTER BAR, CHIPS + DROPDOWNS (redesign only)
+  Hidden by default so flag-off pages are unchanged. Chips compose the
+  .ui-filter-chip primitive from base.css and only add what it lacks.
+  See REDESIGN.md sections 6.2/6.3.
+----------------------------------------------------------------------------- */
+.filter-bar,
+.results-count {
+  display: none;
+}
+
+:root[data-redesign='on'] .filter-bar,
+body.redesign-enabled .filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+  max-width: var(--container-max-width);
+  margin-inline: auto;
+  padding: var(--space-sm) var(--space-sm-md) 0;
+}
+
+:root[data-redesign='on'] .filter-bar__group,
+body.redesign-enabled .filter-bar__group {
+  position: relative;
+}
+
+/* Chips -------------------------------------------------------------------- */
+
+/* buttons.css styles bare `button` and `button:hover` in the legacy palette.
+   Those beat .ui-filter-chip on specificity, so the chip's colours are
+   restated here inside the gated scope. */
+:root[data-redesign='on'] .filter-chip,
+body.redesign-enabled .filter-chip {
+  min-height: 44px;
+  border: 1px solid var(--nyc-medium-gray);
+  background-color: var(--nyc-surface-card);
+  color: var(--nyc-navy);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .filter-chip:hover,
+body.redesign-enabled .filter-chip:hover {
+  border-color: var(--nyc-green);
+  background-color: var(--nyc-surface-card);
+  color: var(--nyc-navy);
+}
+
+:root[data-redesign='on'] .filter-chip--active,
+:root[data-redesign='on'] .filter-chip--active:hover,
+body.redesign-enabled .filter-chip--active,
+body.redesign-enabled .filter-chip--active:hover {
+  border-color: var(--nyc-green);
+  background-color: var(--nyc-surface-active);
+  color: var(--nyc-green);
+}
+
+:root[data-redesign='on'] .filter-chip:disabled,
+body.redesign-enabled .filter-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+:root[data-redesign='on'] .filter-chip__chevron,
+body.redesign-enabled .filter-chip__chevron {
+  font-size: 10px;
+  color: var(--nyc-medium-gray);
+}
+
+:root[data-redesign='on'] .filter-chip--active .filter-chip__chevron,
+body.redesign-enabled .filter-chip--active .filter-chip__chevron {
+  color: var(--nyc-green);
+}
+
+:root[data-redesign='on'] .filter-chip:focus-visible,
+:root[data-redesign='on'] .filter-bar__clear:focus-visible,
+body.redesign-enabled .filter-chip:focus-visible,
+body.redesign-enabled .filter-bar__clear:focus-visible {
+  outline: 2px solid var(--nyc-green);
+  outline-offset: 2px;
+}
+
+/* Dropdown ----------------------------------------------------------------- */
+
+:root[data-redesign='on'] .filter-dropdown,
+body.redesign-enabled .filter-dropdown {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + var(--space-xxs));
+  left: 0;
+  min-width: 220px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: var(--space-xxs) 0;
+  border: 1px solid var(--nyc-surface-border);
+  border-radius: var(--radius-md);
+  background-color: var(--nyc-white);
+  box-shadow: var(--shadow-lg);
+  list-style: none;
+}
+
+:root[data-redesign='on'] .filter-dropdown[hidden],
+body.redesign-enabled .filter-dropdown[hidden] {
+  display: none;
+}
+
+:root[data-redesign='on'] .filter-dropdown__option,
+body.redesign-enabled .filter-dropdown__option {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+  justify-content: space-between;
+  min-height: 44px;
+  padding: var(--space-xs) var(--space-sm);
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .filter-dropdown__option:hover,
+body.redesign-enabled .filter-dropdown__option:hover {
+  background-color: var(--nyc-light-gray);
+}
+
+:root[data-redesign='on'] .filter-dropdown__option[aria-selected='true'],
+body.redesign-enabled .filter-dropdown__option[aria-selected='true'] {
+  background-color: var(--nyc-light-pink);
+  font-weight: var(--font-weight-medium);
+}
+
+/* Checkmark shows selection without relying on colour alone. */
+:root[data-redesign='on'] .filter-dropdown__option::after,
+body.redesign-enabled .filter-dropdown__option::after {
+  content: '';
+  color: var(--nyc-fuschia);
+}
+
+:root[data-redesign='on'] .filter-dropdown__option[aria-selected='true']::after,
+body.redesign-enabled .filter-dropdown__option[aria-selected='true']::after {
+  content: '\2713';
+}
+
+/* Clear all + results count ------------------------------------------------ */
+
+:root[data-redesign='on'] .filter-bar__clear,
+body.redesign-enabled .filter-bar__clear {
+  min-height: 44px;
+  padding-inline: var(--space-xs);
+  color: var(--nyc-fuschia);
+  font-size: var(--font-xs-md);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .filter-bar__clear[hidden],
+body.redesign-enabled .filter-bar__clear[hidden] {
+  display: none;
+}
+
+:root[data-redesign='on'] .results-count,
+body.redesign-enabled .results-count {
+  display: block;
+  max-width: var(--container-max-width);
+  margin-inline: auto;
+  padding: var(--space-sm) var(--space-sm-md) var(--space-xs);
+  color: var(--nyc-charcoal);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+}
+
+@media (max-width: 600px) {
+  :root[data-redesign='on'] .filter-bar,
+  body.redesign-enabled .filter-bar {
+    padding-inline: var(--space-sm);
+  }
+
+  :root[data-redesign='on'] .filter-dropdown,
+  body.redesign-enabled .filter-dropdown {
+    min-width: min(280px, calc(100vw - 2 * var(--space-sm)));
+  }
+}

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -1,0 +1,217 @@
+// Shared filter bar for the redesigned discovery pages: chip triggers,
+// listbox dropdowns, clear-all, and the results count. Behaviour is gated on
+// the redesign flag. Data filtering is not done here — state changes are
+// published as `filters:change` for page code to consume.
+// See REDESIGN.md sections 6.2/6.3.
+
+// === CONSTANTS ===
+
+/** Filters offered per page type, in display order. */
+const FILTER_SETS = {
+    popups: ['borough', 'neighborhood', 'type', 'dates'],
+    'date-ideas': ['vibe', 'budget', 'neighborhood'],
+};
+
+const ACTIVE_CHIP_CLASS = 'filter-chip--active';
+
+// === PURE STATE HELPERS ===
+
+/** Builds an empty state object keyed by the page's filters. */
+function createFilterState(filters) {
+    return filters.reduce((state, filter) => {
+        state[filter] = null;
+        return state;
+    }, {});
+}
+
+/**
+ * Selects a value for a filter. Choosing the value that is already selected
+ * clears it, so a chip can be toggled off without reaching for Clear all.
+ * Unknown filters are ignored. Returns a new object.
+ */
+function selectOption(state, filter, value) {
+    if (!Object.prototype.hasOwnProperty.call(state, filter)) return { ...state };
+    const next = { ...state };
+    next[filter] = next[filter] === value ? null : value;
+    return next;
+}
+
+function clearFilter(state, filter) {
+    const next = { ...state };
+    if (Object.prototype.hasOwnProperty.call(next, filter)) next[filter] = null;
+    return next;
+}
+
+function clearAll(state) {
+    return createFilterState(Object.keys(state));
+}
+
+function getActiveCount(state) {
+    return Object.values(state).filter(value => value !== null).length;
+}
+
+function isAnyActive(state) {
+    return getActiveCount(state) > 0;
+}
+
+/** Chips show the selected option's label, falling back to the filter name. */
+function getChipLabel(filterLabel, selectedLabel) {
+    return selectedLabel || filterLabel;
+}
+
+/** e.g. "1 event found" / "16 events found". */
+function getResultsCountText(count, noun = 'event') {
+    return `${count} ${count === 1 ? noun : `${noun}s`} found`;
+}
+
+// === DOM WIRING ===
+
+function closeDropdown(chip, dropdown) {
+    if (!dropdown || dropdown.hidden) return;
+    dropdown.hidden = true;
+    chip.setAttribute('aria-expanded', 'false');
+}
+
+function openDropdown(chip, dropdown) {
+    if (!dropdown) return;
+    dropdown.hidden = false;
+    chip.setAttribute('aria-expanded', 'true');
+}
+
+/**
+ * Wires the filter bar found in `doc`. Chips without a dropdown (the "Pick
+ * dates" slot awaiting the date picker) are left inert rather than opening an
+ * empty menu.
+ */
+function initFilters(doc) {
+    const bar = doc.querySelector('.filter-bar');
+    if (!bar) return null;
+
+    const pageType = bar.dataset.filterPage;
+    const filters = FILTER_SETS[pageType];
+    if (!filters) return null;
+
+    const noun = pageType === 'date-ideas' ? 'date idea' : 'event';
+    const groups = Array.from(bar.querySelectorAll('.filter-bar__group'));
+    const clearButton = bar.querySelector('.filter-bar__clear');
+    const resultsCount = doc.querySelector('.results-count');
+    let state = createFilterState(filters);
+
+    function closeAll(exceptChip) {
+        groups.forEach(group => {
+            const chip = group.querySelector('.filter-chip');
+            if (chip === exceptChip) return;
+            closeDropdown(chip, group.querySelector('.filter-dropdown'));
+        });
+    }
+
+    function render() {
+        groups.forEach(group => {
+            const chip = group.querySelector('.filter-chip');
+            const filter = chip.dataset.filter;
+            const selected = state[filter];
+            const options = Array.from(group.querySelectorAll('[role="option"]'));
+            const selectedOption = options.find(option => option.dataset.value === selected);
+
+            options.forEach(option => {
+                option.setAttribute('aria-selected', String(option.dataset.value === selected));
+            });
+
+            const labelEl = chip.querySelector('.filter-chip__label');
+            if (labelEl) {
+                labelEl.textContent = getChipLabel(chip.dataset.label, selectedOption && selectedOption.dataset.label);
+            }
+            chip.classList.toggle(ACTIVE_CHIP_CLASS, Boolean(selected));
+        });
+
+        if (clearButton) clearButton.hidden = !isAnyActive(state);
+        bar.dispatchEvent(
+            new CustomEvent('filters:change', { bubbles: true, detail: { state: { ...state }, pageType } })
+        );
+    }
+
+    groups.forEach(group => {
+        const chip = group.querySelector('.filter-chip');
+        const dropdown = group.querySelector('.filter-dropdown');
+
+        chip.addEventListener('click', () => {
+            // The dates chip has no dropdown yet; leave it inert.
+            if (!dropdown) return;
+            const willOpen = dropdown.hidden;
+            closeAll(chip);
+            if (willOpen) {
+                openDropdown(chip, dropdown);
+            } else {
+                closeDropdown(chip, dropdown);
+            }
+        });
+
+        if (!dropdown) return;
+
+        dropdown.querySelectorAll('[role="option"]').forEach(option => {
+            option.addEventListener('click', () => {
+                state = selectOption(state, chip.dataset.filter, option.dataset.value);
+                render();
+                closeDropdown(chip, dropdown);
+                chip.focus();
+            });
+        });
+    });
+
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            state = clearAll(state);
+            closeAll(null);
+            render();
+        });
+    }
+
+    doc.addEventListener('keydown', event => {
+        if (event.key !== 'Escape') return;
+        const openGroup = groups.find(group => {
+            const dropdown = group.querySelector('.filter-dropdown');
+            return dropdown && !dropdown.hidden;
+        });
+        if (!openGroup) return;
+        const chip = openGroup.querySelector('.filter-chip');
+        closeDropdown(chip, openGroup.querySelector('.filter-dropdown'));
+        chip.focus();
+    });
+
+    doc.addEventListener('click', event => {
+        if (!bar.contains(event.target)) closeAll(null);
+    });
+
+    render();
+
+    return {
+        getState: () => ({ ...state }),
+        setResultsCount: count => {
+            if (resultsCount) resultsCount.textContent = getResultsCountText(count, noun);
+        },
+    };
+}
+
+// === BOOTSTRAP ===
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.REDESIGN_FLAG || !window.REDESIGN_FLAG.isEnabled()) return;
+        initFilters(document);
+    });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        FILTER_SETS,
+        createFilterState,
+        selectOption,
+        clearFilter,
+        clearAll,
+        isAnyActive,
+        getActiveCount,
+        getChipLabel,
+        getResultsCountText,
+        initFilters,
+    };
+}

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -14,6 +14,12 @@ const FILTER_SETS = {
 
 const ACTIVE_CHIP_CLASS = 'filter-chip--active';
 
+/** Where each page renders its results, so the count can report on them. */
+const RESULTS_CONTAINERS = {
+    popups: '#popupsGrid',
+    'date-ideas': '#dateIdeasGrid',
+};
+
 // === PURE STATE HELPERS ===
 
 /** Builds an empty state object keyed by the page's filters. */
@@ -52,6 +58,21 @@ function getActiveCount(state) {
 
 function isAnyActive(state) {
     return getActiveCount(state) > 0;
+}
+
+/**
+ * Resolves where roving focus should land inside a listbox. `currentIndex` is
+ * -1 when focus is still on the chip, so the list is entered from whichever
+ * end matches the direction. Returns null for unhandled keys or empty lists.
+ */
+function getNextOptionIndex(currentIndex, key, length) {
+    if (length === 0) return null;
+    if (key === 'Home') return 0;
+    if (key === 'End') return length - 1;
+    if (key !== 'ArrowDown' && key !== 'ArrowUp') return null;
+    if (currentIndex === -1) return key === 'ArrowDown' ? 0 : length - 1;
+    const step = key === 'ArrowDown' ? 1 : -1;
+    return (currentIndex + step + length) % length;
 }
 
 /** Chips show the selected option's label, falling back to the filter name. */
@@ -148,13 +169,47 @@ function initFilters(doc) {
 
         if (!dropdown) return;
 
-        dropdown.querySelectorAll('[role="option"]').forEach(option => {
-            option.addEventListener('click', () => {
-                state = selectOption(state, chip.dataset.filter, option.dataset.value);
-                render();
-                closeDropdown(chip, dropdown);
-                chip.focus();
-            });
+        const options = Array.from(dropdown.querySelectorAll('[role="option"]'));
+
+        // Options are focusable programmatically only; arrow keys move a
+        // roving focus through them, per the listbox pattern.
+        options.forEach(option => {
+            option.tabIndex = -1;
+        });
+
+        function choose(option) {
+            state = selectOption(state, chip.dataset.filter, option.dataset.value);
+            render();
+            closeDropdown(chip, dropdown);
+            chip.focus();
+        }
+
+        options.forEach(option => {
+            option.addEventListener('click', () => choose(option));
+        });
+
+        group.addEventListener('keydown', event => {
+            const index = options.indexOf(event.target);
+            const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp';
+
+            // Home/End only apply once focus is already inside the list.
+            if (!isArrow && index === -1) return;
+
+            if ((event.key === 'Enter' || event.key === ' ') && index !== -1) {
+                event.preventDefault();
+                choose(options[index]);
+                return;
+            }
+
+            const nextIndex = getNextOptionIndex(index, event.key, options.length);
+            if (nextIndex === null) return;
+
+            event.preventDefault();
+            if (isArrow && dropdown.hidden) {
+                closeAll(chip);
+                openDropdown(chip, dropdown);
+            }
+            options[nextIndex].focus();
         });
     });
 
@@ -182,13 +237,27 @@ function initFilters(doc) {
         if (!bar.contains(event.target)) closeAll(null);
     });
 
+    function setResultsCount(count) {
+        if (resultsCount) resultsCount.textContent = getResultsCountText(count, noun);
+    }
+
+    // The count reflects whatever the page has rendered; results arrive
+    // asynchronously from Sanity, so watch the container rather than
+    // reporting a stale zero.
+    const resultsContainer = doc.querySelector(RESULTS_CONTAINERS[pageType] || '');
+    if (resultsContainer && resultsCount) {
+        const syncCount = () => setResultsCount(resultsContainer.childElementCount);
+        syncCount();
+        if (typeof MutationObserver !== 'undefined') {
+            new MutationObserver(syncCount).observe(resultsContainer, { childList: true });
+        }
+    }
+
     render();
 
     return {
         getState: () => ({ ...state }),
-        setResultsCount: count => {
-            if (resultsCount) resultsCount.textContent = getResultsCountText(count, noun);
-        },
+        setResultsCount,
     };
 }
 
@@ -204,6 +273,7 @@ if (typeof document !== 'undefined') {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         FILTER_SETS,
+        getNextOptionIndex,
         createFilterState,
         selectOption,
         clearFilter,

--- a/tests/e2e/redesign-filters.spec.js
+++ b/tests/e2e/redesign-filters.spec.js
@@ -1,0 +1,200 @@
+const { test, expect } = require('@playwright/test')
+
+const typeChip = (page) => page.getByRole('button', { name: /^Type/ })
+const boroughChip = (page) => page.getByRole('button', { name: /^Borough/ })
+const clearAll = (page) => page.getByRole('button', { name: /clear all/i })
+
+test('filter chips open a listbox of options when the flag is on', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(typeChip(page)).toHaveAttribute('aria-expanded', 'false')
+  await typeChip(page).click()
+
+  await expect(typeChip(page)).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeVisible()
+  await expect(page.getByRole('option', { name: /Beauty/ })).toBeVisible()
+})
+
+test('selecting an option activates the chip and reveals clear all', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(clearAll(page)).toBeHidden()
+
+  await typeChip(page).click()
+  await page.getByRole('option', { name: /Food & Drink/ }).click()
+
+  await expect(page.getByRole('button', { name: /^Food & Drink/ })).toHaveClass(/filter-chip--active/)
+  await expect(clearAll(page)).toBeVisible()
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeHidden()
+})
+
+test('an active chip takes the redesign green palette', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).click()
+  await page.getByRole('option', { name: /Wellness/ }).click()
+
+  const styles = await page.getByRole('button', { name: /^Wellness/ }).evaluate(async (el) => {
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+    const computed = getComputedStyle(el)
+    return {
+      background: computed.backgroundColor,
+      color: computed.color,
+      borderColor: computed.borderColor,
+    }
+  })
+
+  expect(styles.background).toBe('rgb(234, 242, 237)') // --nyc-green-light
+  expect(styles.color).toBe('rgb(45, 106, 79)') // --nyc-green
+  expect(styles.borderColor).toBe('rgb(45, 106, 79)')
+})
+
+test('choosing the selected option again clears that filter', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).click()
+  await page.getByRole('option', { name: /Market/ }).click()
+  await expect(clearAll(page)).toBeVisible()
+
+  await page.getByRole('button', { name: /^Market/ }).click()
+  await page.getByRole('option', { name: /Market/ }).click()
+
+  await expect(typeChip(page)).toBeVisible()
+  await expect(clearAll(page)).toBeHidden()
+})
+
+test('opening a second chip closes the first', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).click()
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeVisible()
+
+  await boroughChip(page).click()
+
+  await expect(page.getByRole('listbox', { name: 'Borough' })).toBeVisible()
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeHidden()
+})
+
+test('clicking outside closes the open dropdown', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).click()
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeVisible()
+
+  await page.locator('.hero__supertitle').click()
+
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeHidden()
+  await expect(typeChip(page)).toHaveAttribute('aria-expanded', 'false')
+})
+
+test('Escape closes the dropdown and returns focus to the chip', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).click()
+  await page.keyboard.press('Escape')
+
+  await expect(page.getByRole('listbox', { name: 'Type' })).toBeHidden()
+  await expect(typeChip(page)).toBeFocused()
+})
+
+test('clear all resets every chip and hides itself', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).click()
+  await page.getByRole('option', { name: /Music/ }).click()
+  await boroughChip(page).click()
+  await page.getByRole('option', { name: 'Queens' }).click()
+
+  await clearAll(page).click()
+
+  await expect(typeChip(page)).toBeVisible()
+  await expect(boroughChip(page)).toBeVisible()
+  await expect(clearAll(page)).toBeHidden()
+})
+
+test('filter changes are published for page code to consume', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const received = page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        document.addEventListener(
+          'filters:change',
+          (event) => {
+            if (event.detail.state.borough) resolve(event.detail)
+          },
+          { once: false }
+        )
+      })
+  )
+
+  await boroughChip(page).click()
+  await page.getByRole('option', { name: 'Brooklyn' }).click()
+
+  const detail = await received
+  expect(detail.pageType).toBe('popups')
+  expect(detail.state.borough).toBe('brooklyn')
+})
+
+test('the dates chip is inert until the date picker ships', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const dates = page.getByRole('button', { name: /pick dates/i })
+  await expect(dates).toBeDisabled()
+})
+
+test('date ideas gets vibe and budget filters instead of type and dates', async ({ page }) => {
+  await page.goto('/date-ideas.html?redesign=on')
+
+  await expect(page.getByRole('button', { name: /^Vibe/ })).toBeVisible()
+  await expect(page.getByRole('button', { name: /^Budget/ })).toBeVisible()
+  await expect(page.getByRole('button', { name: /pick dates/i })).toHaveCount(0)
+
+  await page.getByRole('button', { name: /^Budget/ }).click()
+  await page.getByRole('option', { name: 'Under $30' }).click()
+
+  await expect(page.getByRole('button', { name: /^Under \$30/ })).toHaveClass(/filter-chip--active/)
+})
+
+test('hovering a chip keeps the redesign palette, not the legacy button fuchsia', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await boroughChip(page).hover()
+  const hovered = await boroughChip(page).evaluate(async (el) => {
+    // Colour transitions must settle or the sample catches a mid-fade blend.
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+    return { isHovered: el.matches(':hover'), background: getComputedStyle(el).backgroundColor }
+  })
+  // Guard against a vacuous pass if :hover never applies.
+  expect(hovered.isHovered).toBe(true)
+  // buttons.css styles bare `button:hover` fuchsia; the chip must not inherit it.
+  expect(hovered.background).not.toBe('rgb(216, 30, 91)')
+
+  await typeChip(page).click()
+  await page.getByRole('option', { name: /Music/ }).click()
+  await page.getByRole('button', { name: /^Music/ }).hover()
+  const activeHovered = await page.getByRole('button', { name: /^Music/ }).evaluate(async (el) => {
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+    return { isHovered: el.matches(':hover'), background: getComputedStyle(el).backgroundColor }
+  })
+  expect(activeHovered.isHovered).toBe(true)
+  expect(activeHovered.background).not.toBe('rgb(216, 30, 91)')
+})
+
+test('filter bar stays hidden when the redesign flag is off', async ({ page }) => {
+  await page.goto('/pop-ups.html')
+
+  await expect(page.locator('.filter-bar')).toBeHidden()
+  await expect(page.locator('.results-count')).toBeHidden()
+})
+
+test('chips wrap without horizontal overflow on a small phone', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(typeChip(page)).toBeVisible()
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow).toBe(0)
+})

--- a/tests/e2e/redesign-filters.spec.js
+++ b/tests/e2e/redesign-filters.spec.js
@@ -97,6 +97,87 @@ test('Escape closes the dropdown and returns focus to the chip', async ({ page }
   await expect(typeChip(page)).toBeFocused()
 })
 
+test('a keyboard user can open a filter and select an option', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await boroughChip(page).focus()
+  await page.keyboard.press('Enter')
+  await expect(page.getByRole('listbox', { name: 'Borough' })).toBeVisible()
+
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('option', { name: 'Manhattan' })).toBeFocused()
+
+  await page.keyboard.press('Enter')
+
+  await expect(page.getByRole('button', { name: /^Manhattan/ })).toHaveClass(/filter-chip--active/)
+  await expect(page.getByRole('listbox', { name: 'Borough' })).toBeHidden()
+  await expect(page.getByRole('button', { name: /^Manhattan/ })).toBeFocused()
+})
+
+test('arrow keys move through the options and wrap around', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await boroughChip(page).focus()
+  await page.keyboard.press('Enter')
+
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('option', { name: 'Brooklyn' })).toBeFocused()
+
+  await page.keyboard.press('ArrowUp')
+  await expect(page.getByRole('option', { name: 'Manhattan' })).toBeFocused()
+
+  // Wrapping backwards from the first option lands on the last.
+  await page.keyboard.press('ArrowUp')
+  await expect(page.getByRole('option', { name: 'Citywide' })).toBeFocused()
+
+  // And forwards from the last wraps to the first.
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('option', { name: 'Manhattan' })).toBeFocused()
+})
+
+test('Space selects the focused option', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await typeChip(page).focus()
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press(' ')
+
+  await expect(page.getByRole('button', { name: /^Food & Drink/ })).toHaveClass(/filter-chip--active/)
+})
+
+test('the keyboard-focused option is visibly indicated', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await boroughChip(page).focus()
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('ArrowDown')
+
+  const indicator = await page.getByRole('option', { name: 'Manhattan' }).evaluate((el) => {
+    const computed = getComputedStyle(el)
+    return {
+      outlineStyle: computed.outlineStyle,
+      outlineWidth: parseFloat(computed.outlineWidth),
+    }
+  })
+
+  expect(indicator.outlineStyle).not.toBe('none')
+  expect(indicator.outlineWidth).toBeGreaterThan(0)
+})
+
+test('Escape from inside the options closes the menu and restores focus', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await boroughChip(page).focus()
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('Escape')
+
+  await expect(page.getByRole('listbox', { name: 'Borough' })).toBeHidden()
+  await expect(boroughChip(page)).toBeFocused()
+})
+
 test('clear all resets every chip and hides itself', async ({ page }) => {
   await page.goto('/pop-ups.html?redesign=on')
 
@@ -179,6 +260,41 @@ test('hovering a chip keeps the redesign palette, not the legacy button fuchsia'
   })
   expect(activeHovered.isHovered).toBe(true)
   expect(activeHovered.background).not.toBe('rgb(216, 30, 91)')
+})
+
+test('the results count reports how many results are on the page', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await page.evaluate(() => {
+    const grid = document.getElementById('popupsGrid')
+    for (let i = 0; i < 3; i += 1) {
+      const tile = document.createElement('a')
+      tile.className = 'popup-tile'
+      tile.textContent = `Tile ${i}`
+      grid.appendChild(tile)
+    }
+  })
+
+  await expect(page.locator('.results-count')).toHaveText('3 events found')
+
+  await page.evaluate(() => {
+    document.querySelector('#popupsGrid .popup-tile').remove()
+  })
+
+  await expect(page.locator('.results-count')).toHaveText('2 events found')
+})
+
+test('the results count uses the date idea noun on date ideas', async ({ page }) => {
+  await page.goto('/date-ideas.html?redesign=on')
+
+  await page.evaluate(() => {
+    const grid = document.getElementById('dateIdeasGrid')
+    const tile = document.createElement('a')
+    tile.className = 'popup-tile'
+    grid.appendChild(tile)
+  })
+
+  await expect(page.locator('.results-count')).toHaveText('1 date idea found')
 })
 
 test('filter bar stays hidden when the redesign flag is off', async ({ page }) => {

--- a/tests/e2e/redesign-search.spec.js
+++ b/tests/e2e/redesign-search.spec.js
@@ -42,6 +42,21 @@ test('date ideas gets the search bar but no view toggle', async ({ page }) => {
   await expect(page.getByRole('group', { name: /view mode/i })).toHaveCount(0)
 })
 
+test('hovering the inactive toggle keeps the redesign palette', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await page.getByRole('button', { name: 'Map' }).hover()
+  const hovered = await page.getByRole('button', { name: 'Map' }).evaluate(async (el) => {
+    // Colour transitions must settle or the sample catches a mid-fade blend.
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+    return { isHovered: el.matches(':hover'), background: getComputedStyle(el).backgroundColor }
+  })
+  // Guard against a vacuous pass if :hover never applies.
+  expect(hovered.isHovered).toBe(true)
+  // buttons.css styles bare `button:hover` fuchsia; the toggle must not inherit it.
+  expect(hovered.background).not.toBe('rgb(216, 30, 91)')
+})
+
 test('search controls stay hidden when the redesign flag is off', async ({ page }) => {
   await page.goto('/pop-ups.html')
 

--- a/tests/unit/filters.spec.js
+++ b/tests/unit/filters.spec.js
@@ -3,6 +3,7 @@ const path = require('node:path')
 
 const {
   FILTER_SETS,
+  getNextOptionIndex,
   createFilterState,
   selectOption,
   clearFilter,
@@ -91,6 +92,33 @@ describe('filter state', () => {
     state = clearAll(state)
     expect(isAnyActive(state)).toBe(false)
     expect(Object.keys(state)).toEqual(FILTER_SETS.popups)
+  })
+})
+
+describe('getNextOptionIndex', () => {
+  it('enters the list at the first option going down, the last going up', () => {
+    expect(getNextOptionIndex(-1, 'ArrowDown', 6)).toBe(0)
+    expect(getNextOptionIndex(-1, 'ArrowUp', 6)).toBe(5)
+  })
+
+  it('steps through the list', () => {
+    expect(getNextOptionIndex(0, 'ArrowDown', 6)).toBe(1)
+    expect(getNextOptionIndex(3, 'ArrowUp', 6)).toBe(2)
+  })
+
+  it('wraps at both ends', () => {
+    expect(getNextOptionIndex(5, 'ArrowDown', 6)).toBe(0)
+    expect(getNextOptionIndex(0, 'ArrowUp', 6)).toBe(5)
+  })
+
+  it('jumps to either end for Home and End', () => {
+    expect(getNextOptionIndex(3, 'Home', 6)).toBe(0)
+    expect(getNextOptionIndex(3, 'End', 6)).toBe(5)
+  })
+
+  it('returns null for keys it does not handle or an empty list', () => {
+    expect(getNextOptionIndex(2, 'Tab', 6)).toBeNull()
+    expect(getNextOptionIndex(-1, 'ArrowDown', 0)).toBeNull()
   })
 })
 

--- a/tests/unit/filters.spec.js
+++ b/tests/unit/filters.spec.js
@@ -1,0 +1,201 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  FILTER_SETS,
+  createFilterState,
+  selectOption,
+  clearFilter,
+  clearAll,
+  isAnyActive,
+  getActiveCount,
+  getResultsCountText,
+  getChipLabel,
+} = require('../../resources/js/filters.js')
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+function expectCssToMatch(css, pattern) {
+  const regexSpecialCharacters = new Set(['\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'])
+  const escapedPattern = [...pattern]
+    .map((character) => (regexSpecialCharacters.has(character) ? `\\${character}` : character))
+    .join('')
+  expect(css).toMatch(new RegExp(escapedPattern.replaceAll(/\s+/g, '\\s*')))
+}
+
+describe('filter sets', () => {
+  it('gives pop-ups its four filters, including the dates slot', () => {
+    expect(FILTER_SETS.popups).toEqual(['borough', 'neighborhood', 'type', 'dates'])
+  })
+
+  it('gives date ideas vibe and budget instead, with no dates filter', () => {
+    expect(FILTER_SETS['date-ideas']).toEqual(['vibe', 'budget', 'neighborhood'])
+  })
+})
+
+describe('filter state', () => {
+  it('starts with every filter unset', () => {
+    const state = createFilterState(FILTER_SETS.popups)
+    expect(state).toEqual({ borough: null, neighborhood: null, type: null, dates: null })
+    expect(isAnyActive(state)).toBe(false)
+    expect(getActiveCount(state)).toBe(0)
+  })
+
+  it('records a selection without touching the other filters', () => {
+    const state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'brooklyn')
+    expect(state.borough).toBe('brooklyn')
+    expect(state.type).toBeNull()
+    expect(isAnyActive(state)).toBe(true)
+  })
+
+  it('clears the filter when the selected option is chosen again', () => {
+    let state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'brooklyn')
+    state = selectOption(state, 'borough', 'brooklyn')
+    expect(state.borough).toBeNull()
+    expect(isAnyActive(state)).toBe(false)
+  })
+
+  it('replaces the value when a different option is chosen', () => {
+    let state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'brooklyn')
+    state = selectOption(state, 'borough', 'queens')
+    expect(state.borough).toBe('queens')
+    expect(getActiveCount(state)).toBe(1)
+  })
+
+  it('ignores filters that are not part of the page set', () => {
+    const state = selectOption(createFilterState(FILTER_SETS['date-ideas']), 'type', 'market')
+    expect(state).toEqual({ vibe: null, budget: null, neighborhood: null })
+  })
+
+  it('does not mutate the state it is given', () => {
+    const original = createFilterState(FILTER_SETS.popups)
+    selectOption(original, 'borough', 'bronx')
+    expect(original.borough).toBeNull()
+  })
+
+  it('clears one filter and leaves the rest alone', () => {
+    let state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'bronx')
+    state = selectOption(state, 'type', 'beauty')
+    state = clearFilter(state, 'borough')
+    expect(state.borough).toBeNull()
+    expect(state.type).toBe('beauty')
+  })
+
+  it('clears everything at once', () => {
+    let state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'bronx')
+    state = selectOption(state, 'type', 'music')
+    state = clearAll(state)
+    expect(isAnyActive(state)).toBe(false)
+    expect(Object.keys(state)).toEqual(FILTER_SETS.popups)
+  })
+})
+
+describe('chip labels', () => {
+  it('shows the filter name when nothing is selected', () => {
+    expect(getChipLabel('Borough', null)).toBe('Borough')
+  })
+
+  it('shows the selected option label when one is chosen', () => {
+    expect(getChipLabel('Borough', 'Brooklyn')).toBe('Brooklyn')
+  })
+})
+
+describe('getResultsCountText', () => {
+  it('pluralizes the count', () => {
+    expect(getResultsCountText(16)).toBe('16 events found')
+    expect(getResultsCountText(0)).toBe('0 events found')
+  })
+
+  it('uses the singular for exactly one result', () => {
+    expect(getResultsCountText(1)).toBe('1 event found')
+  })
+
+  it('accepts a custom noun for date ideas', () => {
+    expect(getResultsCountText(3, 'date idea')).toBe('3 date ideas found')
+    expect(getResultsCountText(1, 'date idea')).toBe('1 date idea found')
+  })
+})
+
+describe('filter styles', () => {
+  const css = read('resources/css/filters.css')
+
+  it('hides the filter bar and results count by default', () => {
+    expectCssToMatch(css, '.filter-bar, .results-count { display: none; }')
+  })
+
+  it('gates the layout behind the redesign flag scope', () => {
+    expectCssToMatch(css, ":root[data-redesign='on'] .filter-bar")
+    expectCssToMatch(css, 'body.redesign-enabled .filter-bar')
+  })
+
+  it('wraps chips rather than overflowing', () => {
+    expectCssToMatch(css, 'flex-wrap: wrap;')
+  })
+
+  it('styles the dropdown as an elevated card with the selected row highlighted', () => {
+    expectCssToMatch(css, 'box-shadow: var(--shadow-lg);')
+    expectCssToMatch(css, 'background-color: var(--nyc-light-pink);')
+  })
+})
+
+describe('filter markup', () => {
+  const popupsHtml = read('pop-ups.html')
+  const dateIdeasHtml = read('date-ideas.html')
+
+  it('marks each page with its filter set', () => {
+    expect(popupsHtml).toContain('data-filter-page="popups"')
+    expect(dateIdeasHtml).toContain('data-filter-page="date-ideas"')
+  })
+
+  it('gives pop-ups borough, neighborhood, type and an inert dates chip', () => {
+    for (const filter of ['borough', 'neighborhood', 'type', 'dates']) {
+      expect(popupsHtml).toContain(`data-filter="${filter}"`)
+    }
+  })
+
+  it('gives date ideas vibe and budget but no dates chip', () => {
+    expect(dateIdeasHtml).toContain('data-filter="vibe"')
+    expect(dateIdeasHtml).toContain('data-filter="budget"')
+    expect(dateIdeasHtml).not.toContain('data-filter="dates"')
+    expect(dateIdeasHtml).not.toContain('data-filter="type"')
+  })
+
+  it('offers the schema category values, including beauty, on the type filter', () => {
+    for (const value of ['food_drink', 'market', 'art_culture', 'beauty', 'vintage_thrift']) {
+      expect(popupsHtml).toContain(`data-value="${value}"`)
+    }
+  })
+
+  it('offers the schema vibe and budget values on date ideas', () => {
+    for (const value of ['romantic', 'chill', 'under_30', '75_plus']) {
+      expect(dateIdeasHtml).toContain(`data-value="${value}"`)
+    }
+  })
+
+  it('exposes chips as listbox triggers and starts them collapsed', () => {
+    expect(popupsHtml).toContain('aria-haspopup="listbox"')
+    expect(popupsHtml).toContain('aria-expanded="false"')
+    expect(popupsHtml).toContain('role="listbox"')
+    expect(popupsHtml).toContain('role="option"')
+  })
+
+  it('ships clear-all hidden until a filter is active', () => {
+    expect(popupsHtml).toMatch(/class="[^"]*filter-bar__clear[^"]*"[^>]*hidden/)
+  })
+
+  it('announces result counts politely', () => {
+    expect(popupsHtml).toContain('class="results-count"')
+    expect(popupsHtml).toContain('aria-live="polite"')
+  })
+
+  it('links the filter stylesheet and script on both pages', () => {
+    for (const html of [popupsHtml, dateIdeasHtml]) {
+      expect(html).toContain('<link rel="stylesheet" href="resources/css/filters.css">')
+      expect(html).toContain('<script src="resources/js/filters.js" defer></script>')
+    }
+  })
+})


### PR DESCRIPTION
Implements #289 (Epic 3: shared redesign components) — the last of the foundation trio.

## What changed
- **`resources/css/filters.css`** (new): chip row that wraps rather than overflowing, elevated dropdown card (`--radius-md`, `--shadow-lg`) with the selected row in `--nyc-light-pink` plus a checkmark, clear-all text button, and the results-count line with divider. All gated; `.filter-bar` and `.results-count` are `display: none` by default.
- **`resources/js/filters.js`** (new): parameterized by `data-filter-page`. Pure helpers — `createFilterState`, `selectOption` (re-selecting the current value clears it), `clearFilter`, `clearAll`, `isAnyActive`, `getActiveCount`, `getChipLabel`, `getResultsCountText` (pluralized, and noun-aware so date ideas read "3 date ideas found"). Selections publish `filters:change`; a `setResultsCount(n)` handle is returned for page code. **Data filtering stays out of scope** per the issue.
- **Markup**: pop-ups gets Borough / Neighborhood / Type (emoji labels) / Pick dates; date ideas gets Vibe / Budget / Neighborhood. Option values mirror the Sanity enums, including the **beauty** category and **citywide** borough added during Epic 2.

## Notable decisions
- **The "Pick dates" chip ships `disabled`.** Last review flagged controls that announce state they don't have, so rather than an enabled chip with `aria-haspopup` and no menu, it renders visibly dimmed and inert. #290 removes `disabled` and attaches the picker.
- **Chip colours are restated in the gated scope.** `buttons.css` styles bare `button` and `button:hover` in the legacy pink/fuchsia palette at specificity (0,1,1), which outranks the `.ui-filter-chip` primitive (0,1,0) — so hovering a chip turned it fuchsia. The gated rules (0,3,0) restore the redesign palette and add the missing `.filter-chip--active` green treatment. The view toggle from #288 was already immune because its gated rule sets its own background.
- Spec's `.filter-chip .chevron` became `.filter-chip__chevron` for stylelint's BEM pattern.

## Accessibility
Chips are `<button>`s with `aria-haspopup="listbox"` / `aria-expanded`; dropdowns use `role="listbox"` / `role="option"` with `aria-selected`; selection is shown by a checkmark as well as colour; Escape and outside-click close the menu and return focus to the chip; 44px minimum targets; visible focus rings; `aria-live="polite"` on the results count.

## Tests
Written test-first — **28 unit assertions** (filter sets, state machine including no-mutation and unknown-filter guards, chip labels, pluralization, CSS, markup per page, asset links) and **14 e2e** (dropdown open, active palette measured as `--nyc-green-light`, re-select clears, second chip closes the first, outside-click, Escape with focus return, clear-all, published event payload, disabled dates chip, date-ideas variant, hover palette, flag-off invisibility, 375px wrapping).

Full suite: **155 unit + 42 e2e pass**; stylelint and HTMLHint clean.

One testing note worth keeping: two hover assertions initially passed vacuously because Playwright sampled colours mid-transition. They now await `element.getAnimations()` before measuring, and assert `:hover` actually applied, so they fail loudly rather than silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
