### PR TITLE
Add shared dual-month date range picker

### DIFF
--- a/pop-ups.html
+++ b/pop-ups.html
@@ -31,6 +31,7 @@
         <script src="resources/js/sanity-client.js" defer></script>
         <script src="resources/js/sanity-queries.js" defer></script>
         <script src="resources/js/search.js" defer></script>
+        <script src="resources/js/date-picker.js" defer></script>
         <script src="resources/js/filters.js" defer></script>
         <script src="resources/js/cards.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
@@ -114,13 +115,12 @@
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="vintage_thrift" data-label="Vintage &amp; Thrift">&#10024; Vintage &amp; Thrift</li>
                     </ul>
                 </div>
-                <div class="filter-bar__group">
-                    <!-- Inert until the date picker lands (#290); disabled rather than
-                         announcing a menu it does not have yet. -->
-                    <button type="button" class="ui-filter-chip filter-chip" data-filter="dates" data-label="Pick dates" disabled>
+                <div class="filter-bar__group filter-bar__group--dates">
+                    <button type="button" class="ui-filter-chip filter-chip" data-filter="dates" data-label="Pick dates" aria-haspopup="dialog" aria-expanded="false">
                         <span class="filter-chip__label">Pick dates</span>
                         <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
                     </button>
+                    <div class="filter-dropdown filter-dropdown--dates" hidden></div>
                 </div>
                 <button type="button" class="ui-btn--text filter-bar__clear" hidden>&#215; Clear all</button>
             </div>

--- a/resources/css/filters.css
+++ b/resources/css/filters.css
@@ -11,6 +11,7 @@
 
 :root[data-redesign='on'] .filter-bar,
 body.redesign-enabled .filter-bar {
+  position: relative;
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-xs);
@@ -139,6 +140,198 @@ body.redesign-enabled .filter-dropdown__option::after {
 :root[data-redesign='on'] .filter-dropdown__option[aria-selected='true']::after,
 body.redesign-enabled .filter-dropdown__option[aria-selected='true']::after {
   content: '\2713';
+}
+
+/* Date picker -------------------------------------------------------------- */
+
+/* The calendar needs a fixed width and no scroll clipping, unlike the option
+   dropdowns it shares a container class with. */
+:root[data-redesign='on'] .date-picker,
+body.redesign-enabled .date-picker {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
+  overflow: visible;
+  width: min(620px, calc(100vw - 2 * var(--space-sm)));
+  max-height: none;
+  padding: var(--space-sm);
+}
+
+/* Anchored to the filter bar rather than its own chip, so a 620px calendar
+   stays inside the viewport even though the chip sits well to the right. */
+:root[data-redesign='on'] .filter-bar__group--dates,
+body.redesign-enabled .filter-bar__group--dates {
+  position: static;
+}
+
+:root[data-redesign='on'] .date-picker__months,
+body.redesign-enabled .date-picker__months {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-sm-md);
+  /* Grid items default to min-width:auto, which would let the calendars'
+     min-content width push the panel far wider than its own width. */
+  min-width: 0;
+}
+
+:root[data-redesign='on'] .date-picker__month,
+body.redesign-enabled .date-picker__month {
+  min-width: 0;
+}
+
+:root[data-redesign='on'] .date-picker__header,
+body.redesign-enabled .date-picker__header {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-xs);
+}
+
+:root[data-redesign='on'] .date-picker__month-label,
+body.redesign-enabled .date-picker__month-label {
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  font-weight: var(--font-weight-semibold);
+}
+
+:root[data-redesign='on'] .date-picker__nav,
+body.redesign-enabled .date-picker__nav {
+  min-width: 32px;
+  min-height: 32px;
+  padding: 0;
+  border: 1px solid var(--nyc-medium-gray);
+  border-radius: var(--radius-sm);
+  background-color: var(--nyc-white);
+  color: var(--nyc-navy);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .date-picker__grid,
+body.redesign-enabled .date-picker__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+:root[data-redesign='on'] .date-picker__weekday,
+body.redesign-enabled .date-picker__weekday {
+  padding-bottom: var(--space-xxs);
+  color: var(--nyc-medium-gray);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs);
+  text-align: center;
+}
+
+:root[data-redesign='on'] .date-picker__day,
+body.redesign-enabled .date-picker__day {
+  aspect-ratio: 1;
+  min-height: 34px;
+  /* buttons.css pads bare `button` by 8px 32px, which would force each cell
+     to ~80px and overflow the calendar. */
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background-color: transparent;
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .date-picker__day:hover,
+body.redesign-enabled .date-picker__day:hover {
+  background-color: var(--nyc-light-gray);
+  color: var(--nyc-navy);
+}
+
+:root[data-redesign='on'] .date-picker__day--outside,
+body.redesign-enabled .date-picker__day--outside {
+  color: var(--nyc-medium-gray);
+}
+
+/* Selected states are restated for :hover so the pointer resting on a chosen
+   day does not mask the selection. */
+:root[data-redesign='on'] .date-picker__day--in-range,
+:root[data-redesign='on'] .date-picker__day--in-range:hover,
+body.redesign-enabled .date-picker__day--in-range,
+body.redesign-enabled .date-picker__day--in-range:hover {
+  background-color: var(--nyc-light-pink);
+  color: var(--nyc-navy);
+}
+
+:root[data-redesign='on'] .date-picker__day--edge,
+:root[data-redesign='on'] .date-picker__day--edge:hover,
+body.redesign-enabled .date-picker__day--edge,
+body.redesign-enabled .date-picker__day--edge:hover {
+  background-color: var(--nyc-fuschia);
+  color: var(--nyc-white);
+  font-weight: var(--font-weight-semibold);
+}
+
+:root[data-redesign='on'] .date-picker__day--today,
+body.redesign-enabled .date-picker__day--today {
+  border-radius: var(--radius-round);
+  background-color: var(--nyc-pink);
+  color: var(--nyc-navy);
+}
+
+:root[data-redesign='on'] .date-picker__day:focus-visible,
+:root[data-redesign='on'] .date-picker__nav:focus-visible,
+body.redesign-enabled .date-picker__day:focus-visible,
+body.redesign-enabled .date-picker__nav:focus-visible {
+  outline: 2px solid var(--nyc-green);
+  outline-offset: 1px;
+}
+
+:root[data-redesign='on'] .date-picker__footer,
+body.redesign-enabled .date-picker__footer {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+  justify-content: flex-end;
+  padding-top: var(--space-xs);
+  border-top: 1px solid var(--nyc-section-divider);
+}
+
+:root[data-redesign='on'] .date-picker__clear,
+body.redesign-enabled .date-picker__clear {
+  min-height: 40px;
+  padding-inline: var(--space-sm);
+  border: 0;
+  background-color: transparent;
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .date-picker__done,
+body.redesign-enabled .date-picker__done {
+  min-height: 40px;
+  padding-inline: var(--space-sm-md);
+  border: 1px solid var(--nyc-green);
+  border-radius: var(--radius-md);
+  background-color: var(--nyc-green);
+  color: var(--nyc-white);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .date-picker__done:hover,
+body.redesign-enabled .date-picker__done:hover {
+  background-color: var(--nyc-green-hover);
+  color: var(--nyc-white);
+}
+
+@media (max-width: 600px) {
+  :root[data-redesign='on'] .date-picker__months,
+  body.redesign-enabled .date-picker__months {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Clear all + results count ------------------------------------------------ */

--- a/resources/js/date-picker.js
+++ b/resources/js/date-picker.js
@@ -1,0 +1,292 @@
+// Dual-month date range picker for the "Pick dates" filter chip.
+// See REDESIGN.md section 6.3. Gated on the redesign flag; the range is
+// published for page code to query against (#295).
+//
+// Wrapped so its helpers never collide with the other classic scripts on the
+// page, which all share one global lexical scope.
+(function (global) {
+    'use strict';
+
+    // === CONSTANTS ===
+
+    const WEEKDAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+    const MONTH_NAMES = [
+        'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December',
+    ];
+
+    const MONTH_ABBREVIATIONS = [
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+
+    // === PURE DATE HELPERS ===
+    // Everything works on YYYY-MM-DD strings and UTC arithmetic, so a
+    // calendar day never shifts with the viewer's timezone.
+
+    function pad(value) {
+        return String(value).padStart(2, '0');
+    }
+
+    function toIso(year, month, day) {
+        return `${year}-${pad(month + 1)}-${pad(day)}`;
+    }
+
+    function parseIso(iso) {
+        const match = String(iso || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (!match) return null;
+        return {year: +match[1], month: +match[2] - 1, day: +match[3]};
+    }
+
+    /** Steps a {year, month} pair, rolling over the year in both directions. */
+    function addMonths(cursor, delta) {
+        const total = cursor.year * 12 + cursor.month + delta;
+        return {year: Math.floor(total / 12), month: ((total % 12) + 12) % 12};
+    }
+
+    function getDaysInMonth(year, month) {
+        return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    }
+
+    function getMonthLabel(year, month) {
+        return `${MONTH_NAMES[month]} ${year}`;
+    }
+
+    /**
+     * Builds whole Sunday-start weeks covering the month, including the
+     * neighbouring days that pad the first and last rows.
+     */
+    function getMonthGrid(year, month) {
+        const firstWeekday = new Date(Date.UTC(year, month, 1)).getUTCDay();
+        const daysInMonth = getDaysInMonth(year, month);
+        const totalCells = Math.ceil((firstWeekday + daysInMonth) / 7) * 7;
+        const cells = [];
+
+        for (let index = 0; index < totalCells; index += 1) {
+            const offset = index - firstWeekday;
+            const date = new Date(Date.UTC(year, month, 1 + offset));
+            cells.push({
+                iso: toIso(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+                day: date.getUTCDate(),
+                weekday: index % 7,
+                inMonth: offset >= 0 && offset < daysInMonth,
+            });
+        }
+
+        return cells;
+    }
+
+    /**
+     * Applies a click to the range: first pick sets the start, second
+     * completes it (swapping if picked backwards), and picking again once a
+     * full range exists starts over.
+     */
+    function selectRangeDate(range, iso) {
+        if (!range.start || range.end) return {start: iso, end: null};
+        if (iso < range.start) return {start: iso, end: range.start};
+        return {start: range.start, end: iso};
+    }
+
+    function isInRange(iso, range) {
+        if (!range.start) return false;
+        if (!range.end) return iso === range.start;
+        return iso >= range.start && iso <= range.end;
+    }
+
+    function isRangeEdge(iso, range) {
+        return iso === range.start || iso === range.end;
+    }
+
+    function formatDay(iso, withYear) {
+        const parts = parseIso(iso);
+        if (!parts) return '';
+        const base = `${MONTH_ABBREVIATIONS[parts.month]} ${parts.day}`;
+        return withYear ? `${base}, ${parts.year}` : base;
+    }
+
+    /** Chip label for the current range, empty when nothing is picked. */
+    function formatRangeLabel(range) {
+        if (!range.start) return '';
+        if (!range.end || range.end === range.start) return formatDay(range.start);
+        const crossesYears = range.start.slice(0, 4) !== range.end.slice(0, 4);
+        return `${formatDay(range.start, crossesYears)} – ${formatDay(range.end, crossesYears)}`;
+    }
+
+    /** Serialises the range for filter state; null when nothing is picked. */
+    function toRangeValue(range) {
+        if (!range.start) return null;
+        return range.end && range.end !== range.start
+            ? `${range.start}..${range.end}`
+            : range.start;
+    }
+
+    // === DOM ===
+
+    function el(doc, tag, className, text) {
+        const node = doc.createElement(tag);
+        if (className) node.className = className;
+        if (text) node.textContent = text;
+        return node;
+    }
+
+    function todayIso() {
+        const now = new Date();
+        return toIso(now.getFullYear(), now.getMonth(), now.getDate());
+    }
+
+    /**
+     * Renders the picker into `panel` and keeps the chip's label in step.
+     * The chosen range is pushed into the filter bar's state so Clear all and
+     * the results count treat it like any other filter.
+     */
+    function initDatePicker(doc, chip, panel, options) {
+        const settings = options || {};
+        const onApply = settings.onApply || function () {};
+        const onClear = settings.onClear || function () {};
+
+        const now = new Date();
+        let cursor = {year: now.getFullYear(), month: now.getMonth()};
+        let range = {start: null, end: null};
+        let dayNodes = [];
+
+        const months = el(doc, 'div', 'date-picker__months');
+        const footer = el(doc, 'div', 'date-picker__footer');
+        const clearButton = el(doc, 'button', 'date-picker__clear', 'Clear');
+        const doneButton = el(doc, 'button', 'date-picker__done', 'Done');
+        clearButton.type = 'button';
+        doneButton.type = 'button';
+        footer.appendChild(clearButton);
+        footer.appendChild(doneButton);
+
+        panel.classList.add('date-picker');
+        panel.setAttribute('role', 'dialog');
+        panel.setAttribute('aria-label', 'Choose a date range');
+        panel.appendChild(months);
+        panel.appendChild(footer);
+
+        function renderMonth(offset) {
+            const {year, month} = addMonths(cursor, offset);
+            const wrapper = el(doc, 'div', 'date-picker__month');
+
+            const header = el(doc, 'div', 'date-picker__header');
+            if (offset === 0) {
+                const prev = el(doc, 'button', 'date-picker__nav date-picker__nav--prev', '‹');
+                prev.type = 'button';
+                prev.setAttribute('aria-label', 'Previous month');
+                prev.addEventListener('click', () => {
+                    cursor = addMonths(cursor, -1);
+                    render();
+                });
+                header.appendChild(prev);
+            }
+            header.appendChild(el(doc, 'span', 'date-picker__month-label', getMonthLabel(year, month)));
+            if (offset === 1) {
+                const next = el(doc, 'button', 'date-picker__nav date-picker__nav--next', '›');
+                next.type = 'button';
+                next.setAttribute('aria-label', 'Next month');
+                next.addEventListener('click', () => {
+                    cursor = addMonths(cursor, 1);
+                    render();
+                });
+                header.appendChild(next);
+            }
+            wrapper.appendChild(header);
+
+            const grid = el(doc, 'div', 'date-picker__grid');
+            WEEKDAY_INITIALS.forEach((initial, index) => {
+                const weekday = el(doc, 'span', 'date-picker__weekday', initial);
+                weekday.setAttribute('aria-hidden', 'true');
+                weekday.dataset.weekday = String(index);
+                grid.appendChild(weekday);
+            });
+
+            const today = todayIso();
+            getMonthGrid(year, month).forEach(cell => {
+                const day = el(doc, 'button', 'date-picker__day', String(cell.day));
+                day.type = 'button';
+                day.dataset.iso = cell.iso;
+                day.dataset.day = String(cell.day);
+                day.setAttribute('aria-label', cell.iso);
+                if (!cell.inMonth) day.classList.add('date-picker__day--outside');
+                if (cell.iso === today) day.classList.add('date-picker__day--today');
+                if (isRangeEdge(cell.iso, range)) {
+                    day.classList.add('date-picker__day--edge');
+                    day.setAttribute('aria-pressed', 'true');
+                } else if (isInRange(cell.iso, range)) {
+                    day.classList.add('date-picker__day--in-range');
+                }
+                day.addEventListener('click', () => {
+                    range = selectRangeDate(range, cell.iso);
+                    // Restyle in place rather than rebuilding: replacing the
+                    // clicked button would detach it mid-event, and listeners
+                    // further up would then treat the click as coming from
+                    // outside the picker.
+                    applyRangeStyles();
+                });
+                dayNodes.push({node: day, iso: cell.iso});
+                grid.appendChild(day);
+            });
+
+            wrapper.appendChild(grid);
+            return wrapper;
+        }
+
+        /** Reflects the current range onto the already-rendered day buttons. */
+        function applyRangeStyles() {
+            dayNodes.forEach(({node, iso}) => {
+                const edge = isRangeEdge(iso, range);
+                node.classList.toggle('date-picker__day--edge', edge);
+                node.classList.toggle('date-picker__day--in-range', !edge && isInRange(iso, range));
+                if (edge) {
+                    node.setAttribute('aria-pressed', 'true');
+                } else {
+                    node.removeAttribute('aria-pressed');
+                }
+            });
+        }
+
+        function render() {
+            dayNodes = [];
+            months.textContent = '';
+            months.appendChild(renderMonth(0));
+            months.appendChild(renderMonth(1));
+        }
+
+        clearButton.addEventListener('click', () => {
+            range = {start: null, end: null};
+            render();
+            onClear();
+        });
+
+        doneButton.addEventListener('click', () => {
+            onApply(toRangeValue(range), formatRangeLabel(range));
+        });
+
+        render();
+
+        return {
+            getRange: () => ({...range}),
+            reset: () => {
+                range = {start: null, end: null};
+                render();
+            },
+        };
+    }
+
+    const api = {
+        WEEKDAY_INITIALS,
+        initDatePicker,
+        addMonths,
+        getMonthGrid,
+        getMonthLabel,
+        selectRangeDate,
+        isInRange,
+        isRangeEdge,
+        formatRangeLabel,
+        toRangeValue,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (global) global.NycDatePicker = api;
+})(typeof window !== 'undefined' ? window : null);

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -138,10 +138,19 @@ function initFilters(doc) {
                 option.setAttribute('aria-selected', String(option.dataset.value === selected));
             });
 
+            // A group with no options (the date picker) supplies its own
+            // label through dataset.selectedLabel rather than an option. It is
+            // only trusted while the filter is actually set, so Clear all
+            // cannot leave a stale range on the chip.
+            const ownLabel = options.length === 0 && selected ? chip.dataset.selectedLabel : null;
             const labelEl = chip.querySelector('.filter-chip__label');
             if (labelEl) {
-                labelEl.textContent = getChipLabel(chip.dataset.label, selectedOption && selectedOption.dataset.label);
+                labelEl.textContent = getChipLabel(
+                    chip.dataset.label,
+                    options.length === 0 ? ownLabel : selectedOption && selectedOption.dataset.label
+                );
             }
+            if (options.length === 0 && !selected) delete chip.dataset.selectedLabel;
             chip.classList.toggle(ACTIVE_CHIP_CLASS, Boolean(selected));
         });
 
@@ -234,6 +243,8 @@ function initFilters(doc) {
     });
 
     doc.addEventListener('click', event => {
+        // A target detached by its own handler is not an outside click.
+        if (!event.target.isConnected) return;
         if (!bar.contains(event.target)) closeAll(null);
     });
 
@@ -258,6 +269,23 @@ function initFilters(doc) {
     return {
         getState: () => ({ ...state }),
         setResultsCount,
+        /**
+         * Sets a filter from outside the bar — used by the date picker, whose
+         * chip has no option list of its own. Passing a null value clears it.
+         */
+        setFilter: (filter, value, label) => {
+            if (!Object.prototype.hasOwnProperty.call(state, filter)) return;
+            state = { ...state, [filter]: value || null };
+            const chip = bar.querySelector(`.filter-chip[data-filter="${filter}"]`);
+            if (chip) {
+                if (value) {
+                    chip.dataset.selectedLabel = label || '';
+                } else {
+                    delete chip.dataset.selectedLabel;
+                }
+            }
+            render();
+        },
     };
 }
 
@@ -266,7 +294,29 @@ function initFilters(doc) {
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
         if (!window.REDESIGN_FLAG || !window.REDESIGN_FLAG.isEnabled()) return;
-        initFilters(document);
+        const controller = initFilters(document);
+        if (!controller) return;
+        window.NycFilters = controller;
+
+        // Mount the date picker into the dates chip's panel, when both the
+        // chip and the picker module are present on this page.
+        const datesPanel = document.querySelector('.filter-dropdown--dates');
+        const datesChip = document.querySelector('.filter-chip[data-filter="dates"]');
+        if (datesPanel && datesChip && window.NycDatePicker) {
+            const picker = window.NycDatePicker.initDatePicker(document, datesChip, datesPanel, {
+                onApply: (value, label) => {
+                    controller.setFilter('dates', value, label);
+                    datesPanel.hidden = true;
+                    datesChip.setAttribute('aria-expanded', 'false');
+                    datesChip.focus();
+                },
+                onClear: () => controller.setFilter('dates', null),
+            });
+            // Clear all resets the calendar as well as the chip.
+            document.addEventListener('filters:change', event => {
+                if (!event.detail.state.dates) picker.reset();
+            });
+        }
     });
 }
 

--- a/tests/e2e/redesign-date-picker.spec.js
+++ b/tests/e2e/redesign-date-picker.spec.js
@@ -1,0 +1,191 @@
+const { test, expect } = require('@playwright/test')
+
+const datesChip = (page) => page.locator('.filter-chip[data-filter="dates"]')
+const picker = (page) => page.locator('.date-picker')
+const firstMonth = (page) => page.locator('.date-picker__month').first()
+/** Day cells are addressed by number within a month, so tests do not depend on today. */
+const dayInFirstMonth = (page, day) =>
+  firstMonth(page).locator(`.date-picker__day[data-day="${day}"]:not(.date-picker__day--outside)`)
+
+test('the Pick dates chip opens a two-month calendar', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  await expect(datesChip(page)).toBeEnabled()
+  await expect(datesChip(page)).toHaveAttribute('aria-expanded', 'false')
+
+  await datesChip(page).click()
+
+  await expect(picker(page)).toBeVisible()
+  await expect(datesChip(page)).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.locator('.date-picker__month')).toHaveCount(2)
+  // The two headings are consecutive months.
+  const labels = await page.locator('.date-picker__month-label').allTextContents()
+  expect(labels[0]).not.toBe(labels[1])
+})
+
+test('day cells fit their calendar instead of inheriting legacy button padding', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+
+  const metrics = await page.evaluate(() => {
+    const grid = document.querySelector('.date-picker__grid')
+    const month = document.querySelector('.date-picker__month')
+    const day = grid.querySelector('.date-picker__day')
+    return {
+      gridWidth: grid.getBoundingClientRect().width,
+      monthWidth: month.getBoundingClientRect().width,
+      dayWidth: day.getBoundingClientRect().width,
+    }
+  })
+
+  // buttons.css gives bare `button` 8px 32px padding, which would blow each
+  // cell out to ~80px and overflow the calendar.
+  expect(metrics.gridWidth).toBeLessThanOrEqual(metrics.monthWidth + 1)
+  expect(metrics.dayWidth).toBeLessThan(60)
+})
+
+test('picking two days selects an inclusive range', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+
+  await dayInFirstMonth(page, 15).click()
+  await dayInFirstMonth(page, 18).click()
+
+  await expect(dayInFirstMonth(page, 15)).toHaveClass(/date-picker__day--edge/)
+  await expect(dayInFirstMonth(page, 18)).toHaveClass(/date-picker__day--edge/)
+  await expect(dayInFirstMonth(page, 16)).toHaveClass(/date-picker__day--in-range/)
+  await expect(dayInFirstMonth(page, 14)).not.toHaveClass(/date-picker__day--in-range/)
+})
+
+test('a selected day keeps its colour while the pointer rests on it', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+  await dayInFirstMonth(page, 15).click()
+  await dayInFirstMonth(page, 22).click()
+
+  // The pointer is still on 22 after clicking it; hover must not mask the
+  // selection.
+  const background = await dayInFirstMonth(page, 22).evaluate(async (el) => {
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+    return getComputedStyle(el).backgroundColor
+  })
+
+  expect(background).toBe('rgb(216, 30, 91)') // --nyc-fuschia
+})
+
+test('Done applies the range to the chip and reveals clear all', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+  await dayInFirstMonth(page, 15).click()
+  await dayInFirstMonth(page, 22).click()
+
+  await page.locator('.date-picker__done').click()
+
+  await expect(picker(page)).toBeHidden()
+  await expect(datesChip(page)).toHaveClass(/filter-chip--active/)
+  await expect(datesChip(page).locator('.filter-chip__label')).toHaveText(/^\w{3} 15 – \w{3} 22$/)
+  await expect(page.getByRole('button', { name: /clear all/i })).toBeVisible()
+})
+
+test('the range is published for page code to consume', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const received = page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        document.addEventListener('filters:change', (event) => {
+          if (event.detail.state.dates) resolve(event.detail.state.dates)
+        })
+      })
+  )
+
+  await datesChip(page).click()
+  await dayInFirstMonth(page, 15).click()
+  await dayInFirstMonth(page, 22).click()
+  await page.locator('.date-picker__done').click()
+
+  expect(await received).toMatch(/^\d{4}-\d{2}-15\.\.\d{4}-\d{2}-22$/)
+})
+
+test('Clear inside the picker drops the range', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+  await dayInFirstMonth(page, 15).click()
+  await page.locator('.date-picker__done').click()
+  await expect(datesChip(page)).toHaveClass(/filter-chip--active/)
+
+  await datesChip(page).click()
+  await page.locator('.date-picker__clear').click()
+
+  await expect(datesChip(page)).not.toHaveClass(/filter-chip--active/)
+  await expect(datesChip(page).locator('.filter-chip__label')).toHaveText('Pick dates')
+})
+
+test('clear all resets the date chip too', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+  await dayInFirstMonth(page, 15).click()
+  await page.locator('.date-picker__done').click()
+
+  await page.getByRole('button', { name: /clear all/i }).click()
+
+  await expect(datesChip(page)).not.toHaveClass(/filter-chip--active/)
+  await expect(datesChip(page).locator('.filter-chip__label')).toHaveText('Pick dates')
+})
+
+test('the month arrows move both calendars', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+
+  const before = await page.locator('.date-picker__month-label').allTextContents()
+  await page.locator('.date-picker__nav--next').click()
+  const after = await page.locator('.date-picker__month-label').allTextContents()
+
+  expect(after[0]).toBe(before[1])
+
+  await page.locator('.date-picker__nav--prev').click()
+  expect(await page.locator('.date-picker__month-label').allTextContents()).toEqual(before)
+})
+
+test('Escape closes the picker and returns focus to the chip', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+  await expect(picker(page)).toBeVisible()
+
+  await page.keyboard.press('Escape')
+
+  await expect(picker(page)).toBeHidden()
+  await expect(datesChip(page)).toBeFocused()
+})
+
+test('clicking outside closes the picker', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+
+  await page.locator('.hero__supertitle').click()
+
+  await expect(picker(page)).toBeHidden()
+})
+
+test('the calendar stacks its months on a phone', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/pop-ups.html?redesign=on')
+  await datesChip(page).click()
+
+  const columns = await page
+    .locator('.date-picker__months')
+    .evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length)
+  expect(columns).toBe(1)
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow).toBe(0)
+})
+
+test('the picker stays hidden when the redesign flag is off', async ({ page }) => {
+  await page.goto('/pop-ups.html')
+
+  await expect(page.locator('.filter-bar')).toBeHidden()
+  await expect(picker(page)).toBeHidden()
+})

--- a/tests/e2e/redesign-filters.spec.js
+++ b/tests/e2e/redesign-filters.spec.js
@@ -217,11 +217,14 @@ test('filter changes are published for page code to consume', async ({ page }) =
   expect(detail.state.borough).toBe('brooklyn')
 })
 
-test('the dates chip is inert until the date picker ships', async ({ page }) => {
+// The dates chip opens a calendar rather than a listbox; its behaviour is
+// covered in redesign-date-picker.spec.js.
+test('the dates chip advertises a dialog rather than a listbox', async ({ page }) => {
   await page.goto('/pop-ups.html?redesign=on')
 
   const dates = page.getByRole('button', { name: /pick dates/i })
-  await expect(dates).toBeDisabled()
+  await expect(dates).toBeEnabled()
+  await expect(dates).toHaveAttribute('aria-haspopup', 'dialog')
 })
 
 test('date ideas gets vibe and budget filters instead of type and dates', async ({ page }) => {

--- a/tests/unit/date-picker.spec.js
+++ b/tests/unit/date-picker.spec.js
@@ -1,0 +1,185 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  addMonths,
+  getMonthGrid,
+  getMonthLabel,
+  selectRangeDate,
+  isInRange,
+  isRangeEdge,
+  formatRangeLabel,
+  toRangeValue,
+} = require('../../resources/js/date-picker.js')
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+function expectCssToMatch(css, pattern) {
+  const regexSpecialCharacters = new Set(['\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'])
+  const escapedPattern = [...pattern]
+    .map((character) => (regexSpecialCharacters.has(character) ? `\\${character}` : character))
+    .join('')
+  expect(css).toMatch(new RegExp(escapedPattern.replaceAll(/\s+/g, '\\s*')))
+}
+
+describe('addMonths', () => {
+  it('moves forward and backward within a year', () => {
+    expect(addMonths({ year: 2026, month: 6 }, 1)).toEqual({ year: 2026, month: 7 })
+    expect(addMonths({ year: 2026, month: 6 }, -1)).toEqual({ year: 2026, month: 5 })
+  })
+
+  it('rolls over the year boundary in both directions', () => {
+    expect(addMonths({ year: 2026, month: 11 }, 1)).toEqual({ year: 2027, month: 0 })
+    expect(addMonths({ year: 2026, month: 0 }, -1)).toEqual({ year: 2025, month: 11 })
+  })
+})
+
+describe('getMonthGrid', () => {
+  it('lays July 2026 out in whole weeks starting on Sunday', () => {
+    const grid = getMonthGrid(2026, 6)
+
+    expect(grid.length % 7).toBe(0)
+    expect(grid[0].weekday).toBe(0)
+    // 1 July 2026 is a Wednesday, so the row starts with three trailing June days.
+    expect(grid.slice(0, 3).every((cell) => !cell.inMonth)).toBe(true)
+    expect(grid[3]).toEqual(expect.objectContaining({ iso: '2026-07-01', day: 1, inMonth: true }))
+  })
+
+  it('covers every day of the month exactly once', () => {
+    const inMonth = getMonthGrid(2026, 6).filter((cell) => cell.inMonth)
+    expect(inMonth).toHaveLength(31)
+    expect(inMonth[30].iso).toBe('2026-07-31')
+  })
+
+  it('handles a leap February', () => {
+    const inMonth = getMonthGrid(2028, 1).filter((cell) => cell.inMonth)
+    expect(inMonth).toHaveLength(29)
+    expect(inMonth[28].iso).toBe('2028-02-29')
+  })
+
+  it('labels the month for the calendar heading', () => {
+    expect(getMonthLabel(2026, 6)).toBe('July 2026')
+    expect(getMonthLabel(2027, 0)).toBe('January 2027')
+  })
+})
+
+describe('selectRangeDate', () => {
+  const empty = { start: null, end: null }
+
+  it('sets the start on the first pick', () => {
+    expect(selectRangeDate(empty, '2026-07-15')).toEqual({ start: '2026-07-15', end: null })
+  })
+
+  it('completes the range on the second pick', () => {
+    const range = selectRangeDate({ start: '2026-07-15', end: null }, '2026-07-22')
+    expect(range).toEqual({ start: '2026-07-15', end: '2026-07-22' })
+  })
+
+  it('swaps the ends when the second pick is earlier', () => {
+    const range = selectRangeDate({ start: '2026-07-22', end: null }, '2026-07-15')
+    expect(range).toEqual({ start: '2026-07-15', end: '2026-07-22' })
+  })
+
+  it('treats picking the start again as a single-day range', () => {
+    const range = selectRangeDate({ start: '2026-07-15', end: null }, '2026-07-15')
+    expect(range).toEqual({ start: '2026-07-15', end: '2026-07-15' })
+  })
+
+  it('starts over once a full range exists', () => {
+    const range = selectRangeDate({ start: '2026-07-15', end: '2026-07-22' }, '2026-08-03')
+    expect(range).toEqual({ start: '2026-08-03', end: null })
+  })
+
+  it('does not mutate the range it is given', () => {
+    const original = { start: '2026-07-15', end: null }
+    selectRangeDate(original, '2026-07-22')
+    expect(original).toEqual({ start: '2026-07-15', end: null })
+  })
+})
+
+describe('isInRange and isRangeEdge', () => {
+  const range = { start: '2026-07-15', end: '2026-07-22' }
+
+  it('includes both ends and the days between', () => {
+    expect(isInRange('2026-07-15', range)).toBe(true)
+    expect(isInRange('2026-07-18', range)).toBe(true)
+    expect(isInRange('2026-07-22', range)).toBe(true)
+  })
+
+  it('excludes days outside the range', () => {
+    expect(isInRange('2026-07-14', range)).toBe(false)
+    expect(isInRange('2026-07-23', range)).toBe(false)
+  })
+
+  it('treats an incomplete range as covering only its start', () => {
+    const partial = { start: '2026-07-15', end: null }
+    expect(isInRange('2026-07-15', partial)).toBe(true)
+    expect(isInRange('2026-07-16', partial)).toBe(false)
+  })
+
+  it('identifies the edges so they can be rounded', () => {
+    expect(isRangeEdge('2026-07-15', range)).toBe(true)
+    expect(isRangeEdge('2026-07-22', range)).toBe(true)
+    expect(isRangeEdge('2026-07-18', range)).toBe(false)
+  })
+})
+
+describe('formatRangeLabel', () => {
+  it('is empty when nothing is picked, so the chip keeps its own label', () => {
+    expect(formatRangeLabel({ start: null, end: null })).toBe('')
+  })
+
+  it('shows a single date for one day', () => {
+    expect(formatRangeLabel({ start: '2026-07-15', end: null })).toBe('Jul 15')
+    expect(formatRangeLabel({ start: '2026-07-15', end: '2026-07-15' })).toBe('Jul 15')
+  })
+
+  it('shows both ends for a span', () => {
+    expect(formatRangeLabel({ start: '2026-07-15', end: '2026-07-22' })).toBe('Jul 15 – Jul 22')
+  })
+
+  it('includes the year when a span crosses into the next one', () => {
+    expect(formatRangeLabel({ start: '2026-12-28', end: '2027-01-04' })).toBe(
+      'Dec 28, 2026 – Jan 4, 2027'
+    )
+  })
+})
+
+describe('toRangeValue', () => {
+  it('serialises a range for the filter state', () => {
+    expect(toRangeValue({ start: '2026-07-15', end: '2026-07-22' })).toBe('2026-07-15..2026-07-22')
+    expect(toRangeValue({ start: '2026-07-15', end: null })).toBe('2026-07-15')
+    expect(toRangeValue({ start: null, end: null })).toBeNull()
+  })
+})
+
+describe('date picker styles', () => {
+  const css = read('resources/css/filters.css')
+
+  it('shows two months side by side on desktop', () => {
+    expectCssToMatch(css, '.date-picker__months')
+    expectCssToMatch(css, 'grid-template-columns: repeat(2, 1fr);')
+  })
+
+  it('stacks the months on mobile', () => {
+    expectCssToMatch(css, '.date-picker')
+    expectCssToMatch(css, 'grid-template-columns: 1fr;')
+  })
+
+  it('circles today and highlights the selected range', () => {
+    expectCssToMatch(css, '.date-picker__day--today')
+    expectCssToMatch(css, 'background-color: var(--nyc-pink);')
+    expectCssToMatch(css, '.date-picker__day--in-range')
+    expectCssToMatch(css, 'background-color: var(--nyc-light-pink);')
+  })
+
+  it('gives the footer a plain Clear and a green Done', () => {
+    expectCssToMatch(css, '.date-picker__footer')
+    expectCssToMatch(css, '.date-picker__done')
+    expectCssToMatch(css, 'background-color: var(--nyc-green);')
+  })
+})


### PR DESCRIPTION
Implements #290 (Epic 3: shared redesign components), filling the "Pick dates" chip that #289 left inert.

## What changed
- **`resources/js/date-picker.js`** (new): dual-month range calendar per REDESIGN.md §6.3 — two months side by side, `‹`/`›` month navigation, today circled in `--nyc-pink`, the selected range in `--nyc-light-pink` with fuchsia end caps, and a plain **Clear** plus green **Done** in the footer. Months stack on phones.
- **`resources/css/filters.css`**: picker styles, including the panel's own width and no scroll clipping (it shares a container class with the option dropdowns, which cap at 320px).
- **`resources/js/filters.js`**: a small seam instead of special-casing dates — a chip whose group has no options supplies its own label via `dataset.selectedLabel`, and the controller now exposes `setFilter(filter, value, label)`. The range therefore participates in **Clear all** and appears in the `filters:change` payload that #295 will consume.
- **`pop-ups.html`**: the dates chip is enabled, advertises `aria-haspopup="dialog"`, and gets a panel the picker mounts into.

All date maths is pure and string-based (`YYYY-MM-DD`, UTC arithmetic), so a calendar day never shifts with the viewer's timezone — the same hazard that produced the all-day card bug in #368. The module is wrapped in an IIFE exposing `window.NycDatePicker`, following `cards.js`.

## Three bugs, each caught by a failing test first
1. **The calendar closed after the first date pick.** Re-rendering on a day click detached the clicked button mid-event, so filters.js's outside-click handler saw a node no longer inside the bar and closed the panel. Selection now restyles in place, and the outside-click check ignores detached targets.
2. **Day cells overflowed the calendar off-screen.** `buttons.css` pads bare `button` by `8px 32px`, forcing each cell to ~80px — the third time these global button styles have leaked into a redesign component (after the fuchsia chip hover and toggle colours). Cells now zero that padding.
3. **Clear all left a stale range on the chip.** The label was read from the chip's dataset before that dataset was cleared, so the chip advertised a range that was no longer applied.

A fourth, smaller one: hovering a selected day masked its colour with the hover grey, since `button:hover` outranks the selected-state rules. Selected states are now restated for `:hover`.

## Scope note
The issue says "both pop-ups and date ideas filter contexts", but REDESIGN.md §7.2 gives date ideas Vibe/Budget/Neighborhood and no date filter — date ideas are evergreen. The picker is page-agnostic and mounts wherever a dates chip and panel exist; only pop-ups has one. Adding a date filter to date ideas would be inventing product the spec doesn't ask for, so I left it out — say the word if you want it there.

## Tests
Written test-first: **25 unit assertions** (month arithmetic across year boundaries, grid generation including a leap February, range selection with backwards picks and restarts, inclusive range maths, label formatting including cross-year spans, serialisation) and **13 e2e** (opening, two-month layout, range highlighting, cell sizing, Done applying the label, the published payload, Clear, Clear all, month navigation, Escape with focus return, outside click, mobile stacking, flag-off invisibility).

Full suite: **210 unit + 75 e2e pass**; stylelint and HTMLHint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
