### PR TITLE
Add shared redesigned detail modal

### DIFF
--- a/date-ideas.html
+++ b/date-ideas.html
@@ -32,6 +32,7 @@
     <script src="resources/js/search.js" defer></script>
     <script src="resources/js/filters.js" defer></script>
     <script src="resources/js/cards.js" defer></script>
+    <script src="resources/js/modal.js" defer></script>
     <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
   </head>
   <body>

--- a/pop-ups.html
+++ b/pop-ups.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="resources/css/filters.css">
     <link rel="stylesheet" href="resources/css/cards.css">
     <link rel="stylesheet" href="resources/css/popups.css">
+    <link rel="stylesheet" href="resources/css/modals.css">
     <link rel="stylesheet" href="resources/css/footer.css">
     <!-- Removed broken style.css link -->
         <!-- The head, header, and footer content will be dynamically loaded using script below-->
@@ -34,6 +35,7 @@
         <script src="resources/js/date-picker.js" defer></script>
         <script src="resources/js/filters.js" defer></script>
         <script src="resources/js/cards.js" defer></script>
+        <script src="resources/js/modal.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
         <!-- STATIC_JSONLD_START -->
         <!-- STATIC_JSONLD_END -->

--- a/resources/css/modals.css
+++ b/resources/css/modals.css
@@ -81,3 +81,186 @@
 .modal:not(.hidden) {
   display: flex;
 }
+
+/* -----------------------------------------------------------------------------
+  REDESIGNED DETAIL MODAL (gated behind the redesign flag)
+  Split text/photo card with a pink return bar. The legacy .modal styles above
+  are untouched, so flag-off pages are unchanged. See REDESIGN.md section 6.5.
+----------------------------------------------------------------------------- */
+:root[data-redesign='on'] .modal--detail,
+body.redesign-enabled .modal--detail {
+  position: fixed;
+  z-index: 1000;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm);
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+:root[data-redesign='on'] .modal--detail[hidden],
+body.redesign-enabled .modal--detail[hidden] {
+  display: none;
+}
+
+:root[data-redesign='on'] .modal-detail__card,
+body.redesign-enabled .modal-detail__card {
+  display: grid;
+  grid-template-columns: 45% 55%;
+  grid-template-areas:
+    'bar bar'
+    'body media';
+  overflow: hidden;
+  width: 95vw;
+  max-width: 900px;
+  max-height: 90vh;
+  border-radius: var(--radius-lg);
+  background-color: var(--nyc-white);
+  box-shadow: var(--shadow-xl);
+}
+
+:root[data-redesign='on'] .modal-return-bar,
+body.redesign-enabled .modal-return-bar {
+  display: flex;
+  grid-area: bar;
+  gap: var(--space-xs);
+  align-items: center;
+  width: 100%;
+  padding: 12px 20px;
+  border: 0;
+  background-color: var(--nyc-light-pink);
+  color: var(--nyc-fuschia);
+  font-family: var(--nyc-font-body);
+  font-size: 14px;
+  font-weight: var(--font-weight-semibold);
+  text-align: left;
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .modal-return-bar:hover,
+body.redesign-enabled .modal-return-bar:hover {
+  background-color: var(--nyc-light-pink);
+  color: var(--nyc-fuschia);
+  text-decoration: underline;
+}
+
+:root[data-redesign='on'] .modal-detail__body,
+body.redesign-enabled .modal-detail__body {
+  display: flex;
+  grid-area: body;
+  flex-direction: column;
+  gap: var(--space-sm);
+  overflow-y: auto;
+  padding: var(--space-sm-md);
+}
+
+:root[data-redesign='on'] .modal-detail__tags,
+body.redesign-enabled .modal-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+:root[data-redesign='on'] .modal-detail__title,
+body.redesign-enabled .modal-detail__title {
+  margin: 0;
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-display);
+  font-size: clamp(28px, 3vw, 36px);
+}
+
+:root[data-redesign='on'] .modal-detail__when,
+:root[data-redesign='on'] .modal-detail__where,
+:root[data-redesign='on'] .modal-detail__description,
+body.redesign-enabled .modal-detail__when,
+body.redesign-enabled .modal-detail__where,
+body.redesign-enabled .modal-detail__description {
+  margin: 0;
+  color: var(--nyc-charcoal);
+  font-family: var(--nyc-font-body);
+  font-size: 16px;
+}
+
+:root[data-redesign='on'] .modal-detail__venue,
+body.redesign-enabled .modal-detail__venue {
+  display: block;
+  color: var(--nyc-navy);
+  font-weight: var(--font-weight-semibold);
+}
+
+:root[data-redesign='on'] .modal-detail__calendar-label,
+body.redesign-enabled .modal-detail__calendar-label {
+  color: var(--nyc-charcoal);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  font-weight: var(--font-weight-semibold);
+}
+
+:root[data-redesign='on'] .modal-detail__calendar-link,
+body.redesign-enabled .modal-detail__calendar-link {
+  color: var(--nyc-fuschia);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+}
+
+:root[data-redesign='on'] .modal-detail__share,
+body.redesign-enabled .modal-detail__share {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: var(--space-xs) var(--space-sm-md);
+  border: 1px solid var(--nyc-navy);
+  border-radius: var(--radius-md);
+  background-color: var(--nyc-white);
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-xs-md);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+:root[data-redesign='on'] .modal-detail__share:hover,
+body.redesign-enabled .modal-detail__share:hover {
+  background-color: var(--nyc-surface-muted);
+  color: var(--nyc-navy);
+}
+
+:root[data-redesign='on'] .modal-detail__media,
+body.redesign-enabled .modal-detail__media {
+  grid-area: media;
+  overflow: hidden;
+}
+
+:root[data-redesign='on'] .modal-detail__image,
+body.redesign-enabled .modal-detail__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+:root[data-redesign='on'] .modal-detail__share:focus-visible,
+:root[data-redesign='on'] .modal-return-bar:focus-visible,
+:root[data-redesign='on'] .modal-detail__calendar-link:focus-visible,
+body.redesign-enabled .modal-detail__share:focus-visible,
+body.redesign-enabled .modal-return-bar:focus-visible,
+body.redesign-enabled .modal-detail__calendar-link:focus-visible {
+  outline: 2px solid var(--nyc-green);
+  outline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  :root[data-redesign='on'] .modal-detail__card,
+  body.redesign-enabled .modal-detail__card {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'bar'
+      'media'
+      'body';
+  }
+
+  :root[data-redesign='on'] .modal-detail__media,
+  body.redesign-enabled .modal-detail__media {
+    aspect-ratio: 16 / 9;
+  }
+}

--- a/resources/js/modal.js
+++ b/resources/js/modal.js
@@ -1,0 +1,334 @@
+// Shared detail modal for the redesigned discovery pages: overlay, return
+// bar, split desktop / stacked mobile layout, share and add-to-calendar
+// regions. See REDESIGN.md section 6.5. Page-by-page wiring lives with the
+// pages (#297).
+//
+// Wrapped so its helpers never collide with the other classic scripts on the
+// page, which all share one global lexical scope.
+(function (global) {
+    'use strict';
+
+    const EASTERN_TIMEZONE = 'America/New_York';
+
+    const DETAIL_PAGES = {
+        popup: 'pop-up.html',
+        'date-idea': 'date-idea.html',
+    };
+
+    const FOCUSABLE = [
+        'a[href]',
+        'button:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+    ].join(', ');
+
+    // === PURE HELPERS ===
+
+    function isDateOnly(value) {
+        return /^\d{4}-\d{2}-\d{2}$/.test(String(value || ''));
+    }
+
+    /** Date-only values are anchored at noon UTC so the day never shifts. */
+    function parseDate(value) {
+        if (!value) return null;
+        const raw = String(value);
+        const parts = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        const date = parts
+            ? new Date(Date.UTC(+parts[1], +parts[2] - 1, +parts[3], 12, 0, 0))
+            : new Date(raw);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    function pad(value) {
+        return String(value).padStart(2, '0');
+    }
+
+    /** Google's basic UTC stamp, e.g. 20260723T150000Z. */
+    function toCalendarStamp(date) {
+        return (
+            `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+            `T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`
+        );
+    }
+
+    function toCalendarDay(date) {
+        return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}`;
+    }
+
+    function addDays(date, days) {
+        return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+    }
+
+    /**
+     * Builds an "add to Google Calendar" template link. All-day events use
+     * Google's date form with an exclusive end date; timed events without an
+     * end get a one-hour block. Returns '' when there is no date at all.
+     */
+    function buildGoogleCalendarUrl(data) {
+        const start = parseDate(data.start_datetime);
+        if (!start) return '';
+
+        const allDay = isDateOnly(data.start_datetime);
+        const end = parseDate(data.end_datetime);
+        let dates;
+
+        if (allDay) {
+            const lastDay = end || start;
+            dates = `${toCalendarDay(start)}/${toCalendarDay(addDays(lastDay, 1))}`;
+        } else {
+            const finish = end || new Date(start.getTime() + 60 * 60 * 1000);
+            dates = `${toCalendarStamp(start)}/${toCalendarStamp(finish)}`;
+        }
+
+        const location = [data.venue_name, data.address].filter(Boolean).join(', ');
+        const url = new URL('https://calendar.google.com/calendar/render');
+        url.searchParams.set('action', 'TEMPLATE');
+        url.searchParams.set('text', data.name || '');
+        url.searchParams.set('dates', dates);
+        if (location) url.searchParams.set('location', location);
+        if (data.short_desc) url.searchParams.set('details', data.short_desc);
+        return url.toString();
+    }
+
+    /** Payload for the Web Share API, or for a copied link fallback. */
+    function getShareData(data, options) {
+        const settings = options || {};
+        const page = DETAIL_PAGES[settings.type] || DETAIL_PAGES.popup;
+        const origin = settings.origin || '';
+        return {
+            title: data.name || '',
+            text: data.short_desc || '',
+            url: `${origin}/${page}?id=${encodeURIComponent(data.id || '')}`,
+        };
+    }
+
+    function formatEastern(date, options) {
+        return new Intl.DateTimeFormat('en-US', {timeZone: EASTERN_TIMEZONE, ...options}).format(date);
+    }
+
+    function sameEasternDay(a, b) {
+        const key = date => formatEastern(date, {year: 'numeric', month: '2-digit', day: '2-digit'});
+        return key(a) === key(b);
+    }
+
+    /** Human date line for the modal's header block. */
+    function formatDetailDateTime(start, end) {
+        const startDate = parseDate(start);
+        if (!startDate) return '';
+
+        const endDate = parseDate(end);
+        const longDate = formatEastern(startDate, {
+            weekday: 'long',
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+        });
+
+        if (!endDate) return longDate;
+
+        if (!sameEasternDay(startDate, endDate)) {
+            const from = formatEastern(startDate, {month: 'long', day: 'numeric'});
+            const to = formatEastern(endDate, {month: 'long', day: 'numeric', year: 'numeric'});
+            return `${from} – ${to}`;
+        }
+
+        if (isDateOnly(start)) return longDate;
+
+        const time = date => formatEastern(date, {hour: 'numeric', minute: '2-digit'});
+        return `${longDate} · ${time(startDate)} – ${time(endDate)}`;
+    }
+
+    // === DOM ===
+
+    let modalCounter = 0;
+
+    function el(doc, tag, className, text) {
+        const node = doc.createElement(tag);
+        if (className) node.className = className;
+        // Always textContent: detail copy is author-supplied.
+        if (text) node.textContent = text;
+        return node;
+    }
+
+    function getTag(data, type) {
+        const cards = global && global.NycCards;
+        if (!cards) return '';
+        return type === 'date-idea' ? cards.getVibeTag(data.vibe) : cards.getCategoryTag(data.category);
+    }
+
+    function getArea(data) {
+        const cards = global && global.NycCards;
+        return cards ? cards.getAreaLabel(data.neighborhood, data.borough) : '';
+    }
+
+    function buildBody(doc, data, type, calendarUrl) {
+        const body = el(doc, 'div', 'modal-detail__body');
+
+        const tags = el(doc, 'div', 'modal-detail__tags');
+        const taxonomy = getTag(data, type);
+        if (taxonomy) tags.appendChild(el(doc, 'span', 'ui-pill modal-detail__tag', taxonomy));
+        if (data.price) {
+            const free = /\bfree\b/i.test(data.price) ? ' event-card__price--free' : '';
+            tags.appendChild(el(doc, 'span', `ui-pill event-card__price${free}`, data.price));
+        }
+        if (tags.childElementCount) body.appendChild(tags);
+
+        const titleId = `modal-detail-title-${(modalCounter += 1)}`;
+        const title = el(doc, 'h2', 'modal-detail__title', data.name || '');
+        title.id = titleId;
+        body.appendChild(title);
+
+        const when = formatDetailDateTime(data.start_datetime, data.end_datetime);
+        if (when) body.appendChild(el(doc, 'p', 'modal-detail__when', when));
+
+        const area = getArea(data);
+        if (data.venue_name || data.address || area) {
+            body.appendChild(el(doc, 'hr', 'ui-divider'));
+            const where = el(doc, 'p', 'modal-detail__where');
+            if (data.venue_name) {
+                where.appendChild(el(doc, 'span', 'modal-detail__venue', data.venue_name));
+            }
+            const line = [data.address, area].filter(Boolean)[0];
+            if (line) where.appendChild(doc.createTextNode(line));
+            body.appendChild(where);
+        }
+
+        if (data.long_desc || data.short_desc) {
+            body.appendChild(el(doc, 'hr', 'ui-divider'));
+            body.appendChild(
+                el(doc, 'p', 'modal-detail__description', data.long_desc || data.short_desc)
+            );
+        }
+
+        body.appendChild(el(doc, 'hr', 'ui-divider'));
+
+        if (calendarUrl) {
+            const calendar = el(doc, 'p', 'modal-detail__calendar');
+            calendar.appendChild(el(doc, 'span', 'modal-detail__calendar-label', 'Add to Calendar: '));
+            const link = el(doc, 'a', 'modal-detail__calendar-link', 'Add to Google Calendar');
+            link.href = calendarUrl;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            calendar.appendChild(link);
+            body.appendChild(calendar);
+        }
+
+        const share = el(doc, 'button', 'modal-detail__share', 'Share Event');
+        share.type = 'button';
+        body.appendChild(share);
+
+        return {body, titleId, share};
+    }
+
+    /**
+     * Opens the detail modal for an event. The caller owns what data goes in;
+     * this owns the shell, focus handling and dismissal.
+     * @param {Object} data - mapped pop-up or date idea
+     * @param {{type?: 'popup'|'date-idea', returnLabel?: string, document?: Document}} [options]
+     */
+    function openDetailModal(data, options) {
+        const settings = options || {};
+        const doc = settings.document || (global && global.document);
+        if (!doc) throw new Error('openDetailModal requires a document');
+
+        const type = settings.type === 'date-idea' ? 'date-idea' : 'popup';
+        const opener = doc.activeElement;
+        const previousOverflow = doc.body.style.overflow;
+
+        const overlay = el(doc, 'div', 'modal--detail');
+        const card = el(doc, 'div', 'modal-detail__card');
+        card.setAttribute('role', 'dialog');
+        card.setAttribute('aria-modal', 'true');
+
+        const returnBar = el(
+            doc,
+            'button',
+            'modal-return-bar',
+            `← ${settings.returnLabel || 'Return'}`
+        );
+        returnBar.type = 'button';
+        card.appendChild(returnBar);
+
+        const calendarUrl = buildGoogleCalendarUrl(data);
+        const {body, titleId, share} = buildBody(doc, data, type, calendarUrl);
+        card.setAttribute('aria-labelledby', titleId);
+        card.appendChild(body);
+
+        const media = el(doc, 'div', 'modal-detail__media');
+        const image = el(doc, 'img', 'modal-detail__image');
+        image.src = data.img || 'resources/images/images/default-popup-image.webp';
+        // Decorative: the title carries the meaning.
+        image.alt = '';
+        media.appendChild(image);
+        card.appendChild(media);
+
+        overlay.appendChild(card);
+
+        function close() {
+            doc.removeEventListener('keydown', onKeydown, true);
+            overlay.remove();
+            doc.body.style.overflow = previousOverflow;
+            if (opener && typeof opener.focus === 'function') opener.focus();
+        }
+
+        function onKeydown(event) {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                close();
+                return;
+            }
+            if (event.key !== 'Tab') return;
+
+            const focusable = Array.from(card.querySelectorAll(FOCUSABLE)).filter(
+                node => node.offsetParent !== null || node === doc.activeElement
+            );
+            if (focusable.length === 0) return;
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+
+            if (event.shiftKey && doc.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && doc.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        }
+
+        returnBar.addEventListener('click', close);
+        overlay.addEventListener('click', event => {
+            if (event.target === overlay) close();
+        });
+        share.addEventListener('click', () => {
+            const shareData = getShareData(data, {
+                type,
+                origin: global && global.location ? global.location.origin : '',
+            });
+            if (global && global.navigator && typeof global.navigator.share === 'function') {
+                global.navigator.share(shareData).catch(() => {});
+            } else if (global && global.navigator && global.navigator.clipboard) {
+                global.navigator.clipboard.writeText(shareData.url).catch(() => {});
+            }
+        });
+
+        doc.addEventListener('keydown', onKeydown, true);
+        doc.body.appendChild(overlay);
+        doc.body.style.overflow = 'hidden';
+        returnBar.focus();
+
+        return {close, element: overlay};
+    }
+
+    const api = {
+        FOCUSABLE,
+        buildGoogleCalendarUrl,
+        getShareData,
+        formatDetailDateTime,
+        openDetailModal,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (global) global.NycModal = api;
+})(typeof window !== 'undefined' ? window : null);

--- a/tests/e2e/redesign-modal.spec.js
+++ b/tests/e2e/redesign-modal.spec.js
@@ -1,0 +1,185 @@
+const { test, expect } = require('@playwright/test')
+
+const EVENT = {
+  id: 'flavia-lounge',
+  name: 'Flavia Flavor Lounge',
+  start_datetime: '2026-07-23T15:00:00.000Z',
+  end_datetime: '2026-07-23T19:00:00.000Z',
+  category: 'food_drink',
+  price: 'Free',
+  venue_name: '22 Wooster',
+  address: '22 Wooster St, New York, NY 10013',
+  neighborhood: 'SoHo',
+  borough: 'manhattan',
+  short_desc: 'Sip complimentary coffee and tea, and match a drink to your mood.',
+  img: 'resources/images/images/default-popup-image.webp',
+}
+
+const dialog = (page) => page.getByRole('dialog')
+
+/** Opens the modal from a trigger button, so focus restoration can be checked. */
+async function openModal(page, data = EVENT, options = {}) {
+  await page.evaluate(
+    ({ data, options }) => {
+      let trigger = document.getElementById('test-trigger')
+      if (!trigger) {
+        trigger = document.createElement('button')
+        trigger.id = 'test-trigger'
+        trigger.textContent = 'Open detail'
+        document.querySelector('main').prepend(trigger)
+      }
+      trigger.onclick = () => window.NycModal.openDetailModal(data, options)
+    },
+    { data, options }
+  )
+  await page.locator('#test-trigger').click()
+}
+
+test('the modal presents the event with a return bar', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page, EVENT, { returnLabel: 'Return to all pop-ups' })
+
+  await expect(dialog(page)).toBeVisible()
+  await expect(page.locator('.modal-return-bar')).toHaveText(/Return to all pop-ups/)
+  await expect(page.locator('.modal-detail__title')).toHaveText('Flavia Flavor Lounge')
+  await expect(page.locator('.modal-detail__when')).toHaveText(/July 23, 2026/)
+  await expect(page.locator('.modal-detail__venue')).toHaveText('22 Wooster')
+  await expect(page.locator('.modal-detail__description')).toHaveText(/complimentary coffee/)
+  await expect(page.locator('.modal-detail__tags')).toContainText('Food & Drink')
+  await expect(page.locator('.modal-detail__tags')).toContainText('Free')
+  await expect(page.locator('.modal-detail__image')).toHaveAttribute('alt', '')
+})
+
+test('the dialog is labelled by its title for assistive tech', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  await expect(dialog(page)).toHaveAttribute('aria-modal', 'true')
+  const labelledBy = await dialog(page).getAttribute('aria-labelledby')
+  expect(labelledBy).toBeTruthy()
+  await expect(page.locator(`#${labelledBy}`)).toHaveText('Flavia Flavor Lounge')
+})
+
+test('the split layout becomes a single column on a phone', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+  const desktopColumns = await page
+    .locator('.modal-detail__card')
+    .evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length)
+  expect(desktopColumns).toBe(2)
+
+  await page.setViewportSize({ width: 375, height: 812 })
+  const mobileColumns = await page
+    .locator('.modal-detail__card')
+    .evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length)
+  expect(mobileColumns).toBe(1)
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  )
+  expect(overflow).toBe(0)
+})
+
+test('focus moves into the dialog and is trapped inside it', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  expect(await page.evaluate(() => document.activeElement.closest('[role="dialog"]') !== null)).toBe(
+    true
+  )
+
+  for (let press = 0; press < 8; press += 1) {
+    await page.keyboard.press('Tab')
+    const inside = await page.evaluate(
+      () => document.activeElement.closest('[role="dialog"]') !== null
+    )
+    expect(inside).toBe(true)
+  }
+})
+
+test('Escape closes the modal and returns focus to what opened it', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  await page.keyboard.press('Escape')
+
+  await expect(dialog(page)).toHaveCount(0)
+  await expect(page.locator('#test-trigger')).toBeFocused()
+})
+
+test('the return bar closes the modal', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  await page.locator('.modal-return-bar').click()
+
+  await expect(dialog(page)).toHaveCount(0)
+})
+
+test('clicking the overlay closes, clicking the card does not', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  await page.locator('.modal-detail__title').click()
+  await expect(dialog(page)).toBeVisible()
+
+  await page.locator('.modal--detail').click({ position: { x: 5, y: 5 } })
+  await expect(dialog(page)).toHaveCount(0)
+})
+
+test('the page behind the modal does not scroll', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  const overflow = await page.evaluate(() => getComputedStyle(document.body).overflow)
+  expect(overflow).toBe('hidden')
+
+  await page.keyboard.press('Escape')
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe('hidden')
+})
+
+test('add to calendar links to Google with the event details', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await openModal(page)
+
+  const href = await page.locator('.modal-detail__calendar-link').getAttribute('href')
+  const url = new URL(href)
+  expect(url.host).toBe('calendar.google.com')
+  expect(url.searchParams.get('text')).toBe('Flavia Flavor Lounge')
+  await expect(page.locator('.modal-detail__calendar-link')).toHaveAttribute('target', '_blank')
+  await expect(page.locator('.modal-detail__calendar-link')).toHaveAttribute(
+    'rel',
+    /noopener/
+  )
+})
+
+test('an evergreen entry omits the calendar link entirely', async ({ page }) => {
+  await page.goto('/date-ideas.html?redesign=on')
+  await openModal(
+    page,
+    { id: 'whitney', name: 'Whitney Free Fridays', vibe: 'cultural', img: EVENT.img },
+    { type: 'date-idea', returnLabel: 'Return to all date ideas' }
+  )
+
+  await expect(page.locator('.modal-detail__calendar-link')).toHaveCount(0)
+  await expect(page.locator('.modal-detail__when')).toHaveCount(0)
+  await expect(page.locator('.modal-return-bar')).toHaveText(/Return to all date ideas/)
+})
+
+test('Share Event offers the share sheet when the browser has one', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await page.evaluate(() => {
+    window.__shared = null
+    navigator.share = (data) => {
+      window.__shared = data
+      return Promise.resolve()
+    }
+  })
+  await openModal(page)
+
+  await page.locator('.modal-detail__share').click()
+
+  const shared = await page.evaluate(() => window.__shared)
+  expect(shared.title).toBe('Flavia Flavor Lounge')
+  expect(shared.url).toContain('pop-up.html?id=flavia-lounge')
+})

--- a/tests/unit/modal.spec.js
+++ b/tests/unit/modal.spec.js
@@ -1,0 +1,154 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  buildGoogleCalendarUrl,
+  getShareData,
+  formatDetailDateTime,
+} = require('../../resources/js/modal.js')
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+function expectCssToMatch(css, pattern) {
+  const regexSpecialCharacters = new Set(['\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'])
+  const escapedPattern = [...pattern]
+    .map((character) => (regexSpecialCharacters.has(character) ? `\\${character}` : character))
+    .join('')
+  expect(css).toMatch(new RegExp(escapedPattern.replaceAll(/\s+/g, '\\s*')))
+}
+
+describe('buildGoogleCalendarUrl', () => {
+  const event = {
+    name: 'Flavia Flavor Lounge',
+    start_datetime: '2026-07-23T15:00:00.000Z',
+    end_datetime: '2026-07-24T23:00:00.000Z',
+    venue_name: '22 Wooster',
+    address: '22 Wooster St, New York, NY 10013',
+    short_desc: 'Sip complimentary coffee and tea.',
+  }
+
+  it('builds a template link carrying the event details', () => {
+    const url = new URL(buildGoogleCalendarUrl(event))
+
+    expect(url.origin + url.pathname).toBe('https://calendar.google.com/calendar/render')
+    expect(url.searchParams.get('action')).toBe('TEMPLATE')
+    expect(url.searchParams.get('text')).toBe('Flavia Flavor Lounge')
+    expect(url.searchParams.get('location')).toBe('22 Wooster, 22 Wooster St, New York, NY 10013')
+    expect(url.searchParams.get('details')).toContain('Sip complimentary coffee')
+  })
+
+  it('encodes the times in Google basic UTC format', () => {
+    const dates = new URL(buildGoogleCalendarUrl(event)).searchParams.get('dates')
+    expect(dates).toBe('20260723T150000Z/20260724T230000Z')
+  })
+
+  it('treats an all-day event as a whole day rather than midnight UTC', () => {
+    const dates = new URL(
+      buildGoogleCalendarUrl({ name: 'All Day', start_datetime: '2026-07-25' })
+    ).searchParams.get('dates')
+    // Google's all-day form is an exclusive end date.
+    expect(dates).toBe('20260725/20260726')
+  })
+
+  it('falls back to a one-hour block when there is no end time', () => {
+    const dates = new URL(
+      buildGoogleCalendarUrl({ name: 'Open End', start_datetime: '2026-07-23T15:00:00.000Z' })
+    ).searchParams.get('dates')
+    expect(dates).toBe('20260723T150000Z/20260723T160000Z')
+  })
+
+  it('returns an empty string when there is no date to add', () => {
+    expect(buildGoogleCalendarUrl({ name: 'Evergreen Idea' })).toBe('')
+  })
+})
+
+describe('getShareData', () => {
+  it('describes the event for the share sheet', () => {
+    const share = getShareData(
+      { id: 'flavia-lounge', name: 'Flavia Flavor Lounge', short_desc: 'Coffee and tea.' },
+      { origin: 'https://nycsliceoflife.com', type: 'popup' }
+    )
+
+    expect(share).toEqual({
+      title: 'Flavia Flavor Lounge',
+      text: 'Coffee and tea.',
+      url: 'https://nycsliceoflife.com/pop-up.html?id=flavia-lounge',
+    })
+  })
+
+  it('points at the date idea page for date ideas', () => {
+    const share = getShareData(
+      { id: 'whitney-fridays', name: 'Whitney Free Fridays' },
+      { origin: 'https://nycsliceoflife.com', type: 'date-idea' }
+    )
+
+    expect(share.url).toBe('https://nycsliceoflife.com/date-idea.html?id=whitney-fridays')
+    expect(share.text).toBe('')
+  })
+
+  it('escapes an id with characters that need encoding', () => {
+    const share = getShareData(
+      { id: 'a b&c', name: 'Odd' },
+      { origin: 'https://example.com', type: 'popup' }
+    )
+    expect(share.url).toBe('https://example.com/pop-up.html?id=a%20b%26c')
+  })
+})
+
+describe('formatDetailDateTime', () => {
+  it('shows a single day with its time range', () => {
+    expect(
+      formatDetailDateTime('2026-07-23T15:00:00.000Z', '2026-07-23T19:00:00.000Z')
+    ).toBe('Thursday, July 23, 2026 · 11:00 AM – 3:00 PM')
+  })
+
+  it('shows both dates for a multi-day event', () => {
+    expect(formatDetailDateTime('2026-07-23', '2026-07-25')).toBe('July 23 – July 25, 2026')
+  })
+
+  it('shows just the date when there is no end', () => {
+    expect(formatDetailDateTime('2026-07-25')).toBe('Saturday, July 25, 2026')
+  })
+
+  it('is empty for an evergreen entry', () => {
+    expect(formatDetailDateTime('')).toBe('')
+  })
+})
+
+describe('modal styles', () => {
+  const css = read('resources/css/modals.css')
+
+  it('gates the redesigned modal behind the flag scope', () => {
+    expectCssToMatch(css, ":root[data-redesign='on'] .modal--detail")
+    expectCssToMatch(css, 'body.redesign-enabled .modal--detail')
+  })
+
+  it('splits the card into text and photo columns on desktop', () => {
+    expectCssToMatch(css, 'grid-template-columns: 45% 55%;')
+    expectCssToMatch(css, 'max-width: 900px;')
+    expectCssToMatch(css, 'width: 95vw;')
+  })
+
+  it('lightens the overlay from the legacy treatment', () => {
+    expectCssToMatch(css, 'background-color: rgba(0, 0, 0, 0.5);')
+  })
+
+  it('styles the pink return bar across the top', () => {
+    expectCssToMatch(css, '.modal-return-bar')
+    expectCssToMatch(css, 'background-color: var(--nyc-light-pink);')
+    expectCssToMatch(css, 'color: var(--nyc-fuschia);')
+  })
+
+  it('stacks to a single column on mobile', () => {
+    expectCssToMatch(css, 'grid-template-columns: 1fr;')
+  })
+
+  it('gives Share Event the outlined navy treatment', () => {
+    expectCssToMatch(css, '.modal-detail__share')
+    expectCssToMatch(css, 'border: 1px solid var(--nyc-navy);')
+  })
+})


### PR DESCRIPTION
Implements #292 (Epic 3: shared redesign components) — the last building block before the page work.

## What changed
- **`resources/css/modals.css`**: appended a gated redesigned modal — pink `.modal-return-bar` across the top, a 45/55 text-and-photo split that stacks to a single column under 768px (photo at 16:9), `900px`/`95vw` card, and the lighter `rgba(0,0,0,0.5)` overlay replacing the legacy `0.8`. The legacy `.modal` rules above are untouched, so flag-off pages render exactly as before.
- **`resources/js/modal.js`** (new): owns the shell and its behaviour — focus moves into the dialog on open and is **trapped**, Escape / the return bar / the overlay all dismiss it, focus returns to whatever opened it, and the page behind is scroll-locked. Content regions follow §6.5 top to bottom: tag pills, Playfair title, date line, location with bold venue, description, "Add to Calendar:" link, outlined Share Event button.
- **`pop-ups.html` / `date-ideas.html`**: link the new script.

Page-by-page wiring is explicitly out of scope (#297); this exposes `window.NycModal.openDetailModal(data, options)` for those pages to call.

## Details worth noting
- **Calendar links** use Google's all-day date form with an exclusive end date for all-day events, and fall back to a one-hour block when a timed event has no end. Evergreen entries (date ideas with no date) get **no** calendar link and no date line at all, rather than an empty region.
- **Date maths** is string-based with date-only values anchored at noon UTC — the same hazard that caused the all-day card bug in #368.
- **Share** uses the Web Share API when the browser has one and falls back to copying the link to the clipboard.
- The photo is `alt=""`; the title beside it carries the meaning.

## A gap the tests caught
`modals.css` was linked on `date-ideas.html` but **never on `pop-ups.html`** — so the modal rendered completely unstyled on the pop-ups page. A layout assertion (two columns on desktop) failed and surfaced it; the stylesheet is now linked on both.

## Tests
Written test-first: **18 unit assertions** (calendar URL construction incl. all-day, open-ended and dateless events; share payloads incl. id encoding; the detail date line for single-day, multi-day and evergreen) and **11 e2e** (content, `aria-modal` + `aria-labelledby`, split vs stacked layout, focus entering and staying trapped over eight tabs, Escape/return-bar/overlay dismissal, click-inside not closing, scroll lock and its release, the calendar link and its absence, and the share sheet payload).

Full suite: **228 unit + 86 e2e pass**; stylelint and HTMLHint clean.

## Related
This is the fourth component to trip over `buttons.css`'s bare `button` rules (padding this time, colours before). REDESIGN.md §6.9 already calls for retiring that pink button system — worth its own issue before the page work in Epic 4, since every remaining component inherits the same surprises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
