### PR TITLE
Add shared interior page shell for supporting pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="resources/css/header.css">
     <link rel="stylesheet" href="resources/css/hero.css">
     <link rel="stylesheet" href="resources/css/buttons.css">
+    <link rel="stylesheet" href="resources/css/interior.css">
     <link rel="stylesheet" href="resources/css/footer.css">
     <!-- Removed broken style.css link -->
     <!-- The head, header, and footer content will be dynamically loaded using script below-->
@@ -26,13 +27,13 @@
   <body>
     <!-- The header content will be dynamically loaded -->
     <main>
-      <section class="hero">
+      <section class="hero hero--interior">
         <div class="hero-content">
           <h1>About Us</h1>
         </div>
       </section>
-      <section class="about-section">
-        <div class="about-image-wrapper">
+      <section class="about-section interior-page">
+        <div class="about-image-wrapper interior-page__media">
           <img 
             src="resources/images/images/profile.webp" 
             alt="Profile picture" 
@@ -41,7 +42,7 @@
             loading="lazy"
           />
         </div>
-        <div class="about-text">
+        <div class="about-text interior-page__content">
           <h2>NYC Slice of Life</h2>
           <p>
             NYC Slice of Life is your curated guide for NYC pop-ups, NYC date ideas, NYC weekend plans!

--- a/contact_us.html
+++ b/contact_us.html
@@ -14,6 +14,7 @@
         <link rel="stylesheet" href="resources/css/header.css">
         <link rel="stylesheet" href="resources/css/hero.css">
         <link rel="stylesheet" href="resources/css/buttons.css">
+        <link rel="stylesheet" href="resources/css/interior.css">
         <link rel="stylesheet" href="resources/css/footer.css">
         <!-- Removed broken style.css link -->
         <!-- The head, header, and footer content will be dynamically loaded using script below-->
@@ -26,13 +27,13 @@
     <body>
         <!-- The header content will be dynamically loaded -->
         <main>
-            <section class="hero">
+            <section class="hero hero--interior">
                 <div class="hero-content">
                     <h1>Contact Us</h1>
                 </div>
             </section>
-            <section class="contact-section">
-                <div class="contact-text">
+            <section class="contact-section interior-page">
+                <div class="contact-text interior-page__content">
                     <h3>We'd love to hear from you!</h3> 
                     <p>Whether you have a pop-up to share, an event to promote, or just want to say hello, we're here for you.</p>
                     <p>Email us at: <a href="mailto:NYCSliceofLife@gmail.com">NYCSliceofLife@gmail.com</a></p>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="resources/css/header.css">
     <link rel="stylesheet" href="resources/css/hero.css">
     <link rel="stylesheet" href="resources/css/buttons.css">
+    <link rel="stylesheet" href="resources/css/interior.css">
     <link rel="stylesheet" href="resources/css/footer.css">
     <!-- Removed broken style.css link -->
     <!-- The head, header, and footer content will be dynamically loaded using script below-->
@@ -26,13 +27,13 @@
   <body>
     <!-- The header content will be dynamically loaded -->
     <main>
-      <section class="hero">
+      <section class="hero hero--interior">
         <div class="hero-content">
           <h1>Privacy Policy</h1>
         </div>
       </section>
-      <section class="privacy-section">
-        <div class="privacy-text">
+      <section class="privacy-section interior-page">
+        <div class="privacy-text interior-page__content">
           <p><strong>Effective Date:</strong> April 24, 2025</p>
           <p>At <strong>NYC Slice of Life</strong> (nycsliceoflife.com), we value your privacy. This page explains what information may be collected when you visit our site and how it may be used.</p>
       

--- a/resources/css/interior.css
+++ b/resources/css/interior.css
@@ -1,0 +1,194 @@
+/* -----------------------------------------------------------------------------
+  INTERIOR PAGE SHELL (redesign only)
+  Shared layout for the supporting pages — About, Contact, Privacy — so their
+  reading column, typography rhythm and spacing match the redesign.
+
+  REDESIGN.md section 7 specifies Pop-Ups, Date Ideas and Home only; there is
+  no interior-page mock. This shell is derived from the design system: cream
+  page, white content card, Playfair headings, Work Sans body, and green as
+  the interactive accent (section 6.9). Adjust here if a mock lands later.
+
+  Gated behind the redesign flag; the legacy per-page CSS is untouched.
+----------------------------------------------------------------------------- */
+
+:root[data-redesign='on'] .interior-page,
+body.redesign-enabled .interior-page {
+  display: block;
+  box-sizing: border-box;
+  /* The legacy per-page section still wraps this; flatten its surface so the
+     content card below is not nested inside a second card. */
+  border: 0;
+  background: none;
+  box-shadow: none;
+  width: 100%;
+  max-width: var(--section-max-width);
+  margin-inline: auto;
+  padding: var(--space-lg) var(--space-sm-md);
+}
+
+:root[data-redesign='on'] .interior-page__content,
+body.redesign-enabled .interior-page__content {
+  padding: var(--space-md);
+  border: 1px solid var(--nyc-surface-border);
+  border-radius: var(--radius-lg);
+  background-color: var(--nyc-white);
+  box-shadow: var(--shadow-sm);
+  color: var(--nyc-charcoal);
+  font-family: var(--nyc-font-body);
+  font-size: 16px;
+  line-height: 1.7;
+  text-align: left;
+}
+
+/* Headings ------------------------------------------------------------------ */
+
+:root[data-redesign='on'] .interior-page__content h2,
+:root[data-redesign='on'] .interior-page__content h3,
+body.redesign-enabled .interior-page__content h2,
+body.redesign-enabled .interior-page__content h3 {
+  margin-top: var(--space-md);
+  margin-bottom: var(--space-xs);
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-display);
+  line-height: 1.25;
+}
+
+:root[data-redesign='on'] .interior-page__content h2,
+body.redesign-enabled .interior-page__content h2 {
+  font-size: clamp(24px, 3vw, 32px);
+}
+
+:root[data-redesign='on'] .interior-page__content h3,
+body.redesign-enabled .interior-page__content h3 {
+  font-size: clamp(20px, 2vw, 24px);
+}
+
+/* The first heading should not push away from the card's own padding. */
+:root[data-redesign='on'] .interior-page__content > :first-child,
+body.redesign-enabled .interior-page__content > :first-child {
+  margin-top: 0;
+}
+
+/* Body copy ----------------------------------------------------------------- */
+
+:root[data-redesign='on'] .interior-page__content p,
+:root[data-redesign='on'] .interior-page__content li,
+body.redesign-enabled .interior-page__content p,
+body.redesign-enabled .interior-page__content li {
+  margin-bottom: var(--space-sm);
+  color: var(--nyc-charcoal);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+:root[data-redesign='on'] .interior-page__content ul,
+:root[data-redesign='on'] .interior-page__content ol,
+body.redesign-enabled .interior-page__content ul,
+body.redesign-enabled .interior-page__content ol {
+  margin-bottom: var(--space-sm);
+  padding-left: var(--space-sm-md);
+}
+
+:root[data-redesign='on'] .interior-page__content strong,
+body.redesign-enabled .interior-page__content strong {
+  color: var(--nyc-navy);
+  font-weight: var(--font-weight-semibold);
+}
+
+:root[data-redesign='on'] .interior-page__content a,
+body.redesign-enabled .interior-page__content a {
+  color: var(--nyc-green);
+  text-decoration: underline;
+}
+
+:root[data-redesign='on'] .interior-page__content a:hover,
+body.redesign-enabled .interior-page__content a:hover {
+  color: var(--nyc-green-hover);
+}
+
+:root[data-redesign='on'] .interior-page__content a:focus-visible,
+body.redesign-enabled .interior-page__content a:focus-visible {
+  outline: 2px solid var(--nyc-green);
+  outline-offset: 2px;
+}
+
+/* Media region --------------------------------------------------------------- */
+
+:root[data-redesign='on'] .interior-page__media,
+body.redesign-enabled .interior-page__media {
+  display: flex;
+  justify-content: center;
+  margin-bottom: var(--space-md);
+}
+
+:root[data-redesign='on'] .interior-page__media img,
+body.redesign-enabled .interior-page__media img {
+  width: 100%;
+  max-width: 256px;
+  height: auto;
+  border-radius: var(--radius-round);
+  box-shadow: var(--shadow-md);
+  object-fit: cover;
+}
+
+/* CTA region ----------------------------------------------------------------- */
+
+:root[data-redesign='on'] .interior-page__cta,
+body.redesign-enabled .interior-page__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+  margin-top: var(--space-md);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--nyc-section-divider);
+}
+
+/* Responsive ------------------------------------------------------------------ */
+
+@media (max-width: 767px) {
+  :root[data-redesign='on'] .interior-page,
+  body.redesign-enabled .interior-page {
+    padding: var(--space-md) var(--space-sm);
+  }
+
+  :root[data-redesign='on'] .interior-page__content,
+  body.redesign-enabled .interior-page__content {
+    padding: var(--space-sm-md);
+  }
+
+  /* Portrait leads the page rather than sitting beside the text. */
+  :root[data-redesign='on'] .interior-page__media,
+  body.redesign-enabled .interior-page__media {
+    margin-bottom: var(--space-sm-md);
+  }
+
+  :root[data-redesign='on'] .interior-page__cta,
+  body.redesign-enabled .interior-page__cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+/* Compact hero -----------------------------------------------------------------
+   Supporting pages keep a single banner image rather than the collage, but the
+   headline follows the redesign treatment so they do not read as legacy pages.
+----------------------------------------------------------------------------- */
+
+:root[data-redesign='on'] .hero--interior,
+body.redesign-enabled .hero--interior {
+  height: auto;
+  min-height: 30vh;
+}
+
+:root[data-redesign='on'] .hero--interior::after,
+body.redesign-enabled .hero--interior::after {
+  background: linear-gradient(to bottom, rgba(0, 27, 46, 0.55), rgba(0, 27, 46, 0.8));
+}
+
+:root[data-redesign='on'] .hero--interior h1,
+body.redesign-enabled .hero--interior h1 {
+  margin-bottom: 0;
+  color: var(--nyc-white);
+  font-size: clamp(36px, 5vw, 56px);
+}

--- a/tests/e2e/redesign-interior.spec.js
+++ b/tests/e2e/redesign-interior.spec.js
@@ -1,0 +1,137 @@
+const { test, expect } = require('@playwright/test')
+
+const PAGES = [
+  { path: '/about.html', heading: /about us/i },
+  { path: '/contact_us.html', heading: /contact us/i },
+  { path: '/privacy_policy.html', heading: /privacy policy/i },
+]
+
+for (const { path, heading } of PAGES) {
+  test(`${path} constrains its reading column when the flag is on`, async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(`${path}?redesign=on`)
+
+    await expect(page.getByRole('heading', { level: 1, name: heading })).toBeVisible()
+
+    const { shellWidth, sectionMax, isCentred } = await page.evaluate(() => {
+      const shell = document.querySelector('.interior-page')
+      const rect = shell.getBoundingClientRect()
+      const max = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--section-max-width')
+      )
+      const rightGutter = window.innerWidth - (rect.left + rect.width)
+      return {
+        shellWidth: rect.width,
+        sectionMax: max,
+        isCentred: Math.abs(rect.left - rightGutter) <= 1,
+      }
+    })
+
+    expect(shellWidth).toBeLessThanOrEqual(sectionMax)
+    expect(isCentred).toBe(true)
+  })
+
+  test(`${path} reads on a white card over the cream page`, async ({ page }) => {
+    await page.goto(`${path}?redesign=on`)
+
+    const content = await page.locator('.interior-page__content').evaluate((el) => {
+      const computed = getComputedStyle(el)
+      return {
+        background: computed.backgroundColor,
+        lineHeight: parseFloat(computed.lineHeight) / parseFloat(computed.fontSize),
+        pageBackground: getComputedStyle(document.body).backgroundColor,
+      }
+    })
+
+    expect(content.background).toBe('rgb(255, 255, 255)')
+    expect(content.pageBackground).not.toBe('rgb(255, 255, 255)')
+    expect(content.lineHeight).toBeGreaterThan(1.5)
+  })
+
+  test(`${path} is unchanged when the flag is off`, async ({ page }) => {
+    await page.goto(path)
+
+    const background = await page
+      .locator('.interior-page__content')
+      .evaluate((el) => getComputedStyle(el).backgroundColor)
+    // The gated card treatment must not apply.
+    expect(background).not.toBe('rgb(255, 255, 255)')
+  })
+
+  test(`${path} fits a phone without sideways scrolling`, async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
+    await page.goto(`${path}?redesign=on`)
+
+    await expect(page.getByRole('heading', { level: 1, name: heading })).toBeVisible()
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow).toBe(0)
+  })
+}
+
+test('interior headings pick up the display serif', async ({ page }) => {
+  await page.goto('/privacy_policy.html?redesign=on')
+
+  const font = await page
+    .locator('.interior-page__content h3')
+    .first()
+    .evaluate((el) => getComputedStyle(el).fontFamily)
+  expect(font).toMatch(/Playfair Display/)
+})
+
+test('interior links use the green accent', async ({ page }) => {
+  await page.goto('/contact_us.html?redesign=on')
+
+  const colour = await page
+    .locator('.interior-page__content a')
+    .first()
+    .evaluate((el) => getComputedStyle(el).color)
+  expect(colour).toBe('rgb(45, 106, 79)') // --nyc-green
+})
+
+test('the about portrait leads the page as a media region', async ({ page }) => {
+  await page.goto('/about.html?redesign=on')
+
+  const media = page.locator('.interior-page__media img')
+  await expect(media).toBeVisible()
+  const radius = await media.evaluate((el) => getComputedStyle(el).borderRadius)
+  expect(radius).toBe('50%')
+})
+
+test('the interior hero follows the redesign headline treatment', async ({ page }) => {
+  await page.goto('/about.html?redesign=on')
+
+  const hero = await page.evaluate(() => {
+    const section = document.querySelector('.hero--interior')
+    const h1 = section.querySelector('h1')
+    return {
+      colour: getComputedStyle(h1).color,
+      heightRatio: section.getBoundingClientRect().height / window.innerHeight,
+    }
+  })
+
+  expect(hero.colour).toBe('rgb(255, 255, 255)')
+  // Shorter than the 50vh legacy banner, leaving room for the content.
+  expect(hero.heightRatio).toBeLessThan(0.45)
+})
+
+test('the interior hero is untouched when the flag is off', async ({ page }) => {
+  await page.goto('/about.html')
+
+  const colour = await page
+    .locator('.hero--interior h1')
+    .evaluate((el) => getComputedStyle(el).color)
+  expect(colour).toBe('rgb(255, 182, 193)') // legacy --nyc-pink
+})
+
+test('the shell does not nest a card inside another card', async ({ page }) => {
+  await page.goto('/privacy_policy.html?redesign=on')
+
+  // The legacy section still wraps the content; only the inner card should
+  // paint a surface.
+  const shell = await page
+    .locator('.interior-page')
+    .evaluate((el) => getComputedStyle(el).backgroundColor)
+  expect(['rgba(0, 0, 0, 0)', 'transparent']).toContain(shell)
+})

--- a/tests/unit/interior-layout.spec.js
+++ b/tests/unit/interior-layout.spec.js
@@ -1,0 +1,78 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+function expectCssToMatch(css, pattern) {
+  const regexSpecialCharacters = new Set(['\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'])
+  const escapedPattern = [...pattern]
+    .map((character) => (regexSpecialCharacters.has(character) ? `\\${character}` : character))
+    .join('')
+  expect(css).toMatch(new RegExp(escapedPattern.replaceAll(/\s+/g, '\\s*')))
+}
+
+const SUPPORTING_PAGES = ['about.html', 'contact_us.html', 'privacy_policy.html']
+
+describe('interior page styles', () => {
+  const css = read('resources/css/interior.css')
+
+  it('leaves the legacy pages alone until the flag is on', () => {
+    expectCssToMatch(css, ":root[data-redesign='on'] .interior-page")
+    expectCssToMatch(css, 'body.redesign-enabled .interior-page')
+  })
+
+  it('constrains the reading column to the shared section width', () => {
+    expectCssToMatch(css, 'max-width: var(--section-max-width);')
+    expectCssToMatch(css, 'margin-inline: auto;')
+  })
+
+  it('sits the content on a white card over the cream page', () => {
+    expectCssToMatch(css, 'background-color: var(--nyc-white);')
+    expectCssToMatch(css, 'border-radius: var(--radius-lg);')
+  })
+
+  it('sets a serif heading and readable body rhythm', () => {
+    expectCssToMatch(css, 'font-family: var(--nyc-font-display);')
+    expectCssToMatch(css, 'line-height: 1.7;')
+  })
+
+  it('uses green as the interior link accent', () => {
+    expectCssToMatch(css, '.interior-page__content a')
+    expectCssToMatch(css, 'color: var(--nyc-green);')
+  })
+
+  it('provides media and CTA regions for pages that need them', () => {
+    expectCssToMatch(css, '.interior-page__media')
+    expectCssToMatch(css, '.interior-page__cta')
+  })
+
+  it('stacks the media above the text on small screens', () => {
+    expectCssToMatch(css, '@media (max-width: 767px)')
+  })
+})
+
+describe('supporting page markup', () => {
+  it.each(SUPPORTING_PAGES)('%s adopts the shared shell', (page) => {
+    const html = read(page)
+    // The shell classes sit alongside each page's existing ones.
+    expect(html).toMatch(/class="[^"]*\binterior-page\b/)
+    expect(html).toMatch(/class="[^"]*\binterior-page__content\b/)
+    expect(html).toContain('<link rel="stylesheet" href="resources/css/interior.css">')
+  })
+
+  it('keeps each page heading and its existing copy', () => {
+    expect(read('about.html')).toContain('<h1>About Us</h1>')
+    expect(read('contact_us.html')).toContain('<h1>Contact Us</h1>')
+    expect(read('contact_us.html')).toContain('NYCSliceofLife@gmail.com')
+    expect(read('privacy_policy.html')).toContain('<h1>Privacy Policy</h1>')
+    expect(read('privacy_policy.html')).toContain('What We Collect')
+  })
+
+  it('marks the about page portrait as the media region', () => {
+    expect(read('about.html')).toContain('interior-page__media')
+  })
+})


### PR DESCRIPTION
Implements #293 (Epic 3), the last open issue in the epic.

## Design provenance — please review the look, not just the code
REDESIGN.md §7 specifies Pop-Ups (7.1), Date Ideas (7.2) and Home (7.3) only. **There is no interior-page mock**, which is why this was originally deferred. Rather than block, the shell is **derived from the design system** — cream page, white content card, Playfair headings, Work Sans body, green as the interactive accent (§6.9). The stylesheet header says exactly this, so it is one obvious place to adjust if a mock arrives later.

## What changed
- **`resources/css/interior.css`** (new): `.interior-page` reading column capped at `--section-max-width` and centred; `.interior-page__content` white card with `--radius-lg`, border and `--shadow-sm`; heading rhythm (h2 `clamp(24–32px)`, h3 `clamp(20–24px)`, Playfair, navy); body at 16px / 1.7 line-height in `--nyc-charcoal`; green underlined links with hover and focus states; `.interior-page__media` (circular portrait) and `.interior-page__cta` regions; tighter padding and a stacked CTA under 768px.
- **Compact hero**: `.hero--interior` drops to 30vh with the redesign's darker gradient and a **white** headline. Without this the supporting pages kept a pink Playfair headline on a full 50vh banner and read as untouched next to the redesigned pages.
- **`about.html` / `contact_us.html` / `privacy_policy.html`**: class hooks and the stylesheet link only — **no content re-architecture**, per the issue.

## A bug the visual check caught
The gated shell also flattens the legacy section's own surface. Without that, `.privacy-section`'s white background painted a **second card behind the content card** — visible as nested boxes. An e2e test now asserts the outer shell paints no surface.

## Tests
Written test-first: **12 unit assertions** (gated scope, section width, card surface, serif headings, green links, media/CTA regions, responsive tier, and that all three pages adopt the hooks and keep their existing copy) and **18 e2e** (constrained + centred column, white card over a non-white page, readable line-height, serif headings, green links, circular portrait, compact hero treatment, no nested cards, no sideways scrolling at 375px, and **flag-off parity on every page**).

Full suite: **240 unit + 104 e2e pass**; stylelint and HTMLHint clean.

## Epic 3
This closes the last open issue. #287 hero, #288 search/toggle, #289 filters, #290 date picker, #291 cards, #292 modal and #293 interior shell are all merged or in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
