### PR TITLE
Document the Epic 3 shared components for the page work ahead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ A Node script (no browser APIs) that queries Sanity directly over HTTPS and rewr
 
 Environment-aware feature flag gating an in-progress redesign, loaded first (blocking, not deferred) in every page's `<head>`. Resolves on/off via, in priority order: `?redesign=on|off` URL param > `window.REDESIGN_CONFIG` (optionally loaded from a separate untracked `resources/js/redesign-config.js`) > hostname-based environment default (dev/staging/prod all default OFF). See README for full config API.
 
+### Redesign shared components (`docs/redesign-components.md`)
+
+Epic 3 built the redesign's shared UI — collage hero, search bar + List/Map toggle, filter bar/chips/dropdowns, date range picker, event cards, detail modal, interior-page shell. **`docs/redesign-components.md` is the reference**: component inventory, public APIs, the events they publish, deviations from REDESIGN.md, and the traps below. Read it before building on them (Epic 4 onwards).
+
+- **Everything is gated, in both halves.** CSS rules are scoped to `:root[data-redesign='on'], body.redesign-enabled`, and anything that must not appear flag-off carries an unscoped `display: none` default. JS bootstraps return early unless `window.REDESIGN_FLAG.isEnabled()`. A component doing only one half leaks into the legacy experience.
+- **New JS modules are wrapped in an IIFE exposing a single `window.NycX`** (`NycCards`, `NycModal`, `NycFilters`, `NycDatePicker`). Classic scripts share one global lexical scope, so a duplicate top-level `const` silently kills the whole file — this happened with `EASTERN_TIMEZONE` between `cards.js` and `pop-ups.js`. An e2e test asserts each redesign page loads with zero page errors.
+- **Components publish events rather than calling each other**: `viewtoggle:change`, `search:change`, `filters:change`. Nothing consumes them yet; that is Epic 4.
+- **`buttons.css` styles the bare `button` selector** in the legacy pink palette with `padding: 8px 32px`, at a specificity that beats the `.ui-*` primitives — it has caused real bugs in redesign components, which currently restate their own colours to defend against it. Tracked in #372.
+- **Anchor date-only strings at noon UTC.** `new Date('2026-07-25')` is UTC midnight, i.e. the previous evening in Eastern time, so all-day events render a day early. `prebuild-events.js`, `cards.js` and `modal.js` all do this.
+
 ### CI/CD gates (branch-specific, see `.github/workflows/`)
 
 - **`staging` branch** (`staging-integration-gate.yml`): Sanity Studio build, Stylelint, HTMLHint, Vitest unit tests, Lychee link check, Lighthouse CI, Playwright e2e smoke tests — plus `security-ci.yml` (ESLint + `npm audit` in `sanity/`, Gitleaks, optional Snyk) and dependency review.
@@ -86,3 +96,4 @@ Full detail in `docs/STANDARDS.md`; CI enforces a subset via Stylelint. Highligh
 - **CSS**: lowercase-hyphenated, BEM-ish (`.block__element--modifier`); custom properties must use one of the prefixes `--nyc-*`, `--space-*`, `--font-*`, `--shadow-*`, `--radius-*`, `--container-*`, `--section-*`, `--carousel-*` (enforced by `.stylelintrc.json`).
 - **JS**: camelCase functions/variables, PascalCase classes, UPPER_SNAKE_CASE constants (e.g. `POPUPS_QUERY`).
 - One CSS file per page/feature under `resources/css/`, linked explicitly in each HTML file's `<head>` (no automatic bundling — new pages must add their own `<link>` tags).
+- **Tests**: CSS is unit-tested by reading the file and regex-asserting selectors/tokens (`expectCssToMatch`); pure JS is unit-tested via the `module.exports` guard; behaviour is tested in Playwright against `?redesign=on` with a companion flag-off assertion. Colour assertions must `await` `element.getAnimations()` before sampling — `getComputedStyle` immediately after a hover or class change reads a mid-transition blend and passes vacuously.

--- a/REDESIGN.md
+++ b/REDESIGN.md
@@ -573,13 +573,37 @@ Add/update the following in `:root` in `resources/css/base.css`:
 
 ---
 
+### 7.4 Supporting Pages (`about.html`, `contact_us.html`, `privacy_policy.html`)
+
+No mock exists for these pages. The shell built in #293 is **derived from the
+design system** rather than from a design, and is recorded here so it is not
+re-litigated:
+
+- Compact hero (30vh) with the redesign's darker gradient and a white headline,
+  replacing the pink headline on a 50vh banner
+- Reading column capped at `--section-max-width`, centred
+- Content on a white card (`--radius-lg`, `--shadow-sm`) over the cream page
+- Playfair section headings, Work Sans body at 16px / 1.7 line-height
+- Green links per §6.9; media (circular portrait) and CTA regions available
+
+Implementation: `resources/css/interior.css`. If a mock is produced later, that
+file is the single place to adjust.
+
+---
+
 ## 9. New CSS Files Needed
 
-| File | Purpose |
-|---|---|
-| `resources/css/filters.css` | Filter bar, filter chips, dropdowns, date range picker |
-| `resources/css/map.css` | Leaflet map container, legend, pin styles, map/list toggle |
-| `resources/css/search.css` | Search bar container, input field, view toggle buttons |
+| File | Purpose | Status |
+|---|---|---|
+| `resources/css/filters.css` | Filter bar, filter chips, dropdowns, date range picker | ✅ Built (#289, #290) |
+| `resources/css/search.css` | Search bar container, input field, view toggle buttons | ✅ Built (#288) |
+| `resources/css/cards.css` | Event card system, standard and featured variants | ✅ Built (#291) |
+| `resources/css/interior.css` | Shell for About/Contact/Privacy (derived — see §7.4) | ✅ Built (#293) |
+| `resources/css/map.css` | Leaflet map container, legend, pin styles | Pending (#299) |
+
+Plus gated additions to existing files: `hero.css` (collage hero, #287) and `modals.css` (detail modal, #292).
+
+Accompanying JS: `search.js`, `filters.js`, `date-picker.js`, `cards.js`, `modal.js` — all built in Epic 3. **See `docs/redesign-components.md` for their public APIs, the events they publish, and the conventions they follow.**
 
 These should be `<link>`ed in the relevant HTML pages only (e.g. `filters.css` and `map.css` only on `pop-ups.html` and `date-ideas.html`).
 

--- a/docs/redesign-components.md
+++ b/docs/redesign-components.md
@@ -1,0 +1,188 @@
+# Redesign Shared Components
+
+> **Status:** Epic 3 complete — every component below is built, tested and merged to `staging`.
+> **Not yet wired:** no page fetches data into these components yet. That is Epic 4 (#294–#299).
+> **Spec:** `REDESIGN.md` §6. **Responsive targets:** `docs/RESPONSIVE-QA.md`.
+
+Everything here is gated behind the redesign feature flag, which is **OFF in all
+environments**. Nothing in this document is user-visible today; append
+`?redesign=on` to any URL to see it.
+
+---
+
+## 1. Component inventory
+
+| Area | CSS | JS | Global | Spec |
+|---|---|---|---|---|
+| Collage hero | `hero.css` (`.hero--collage`) | — | — | §6.1 |
+| Search bar + List/Map toggle | `search.css` | `search.js` | — | §6.2 |
+| Filter bar, chips, dropdowns | `filters.css` | `filters.js` | `window.NycFilters` | §6.2/6.3 |
+| Date range picker | `filters.css` (`.date-picker*`) | `date-picker.js` | `window.NycDatePicker` | §6.3 |
+| Event cards | `cards.css` | `cards.js` | `window.NycCards` | §6.4 |
+| Detail modal | `modals.css` (`.modal--detail*`) | `modal.js` | `window.NycModal` | §6.5 |
+| Interior page shell | `interior.css` | — | — | *derived, see §5* |
+
+Each page `<link>`s and `<script>`s only what it uses; there is no bundler.
+
+---
+
+## 2. The gating contract
+
+Two halves, and both are required — a component that only does one leaks into the
+legacy experience.
+
+**CSS.** Redesign rules are scoped to the dual selector, and anything that must
+not appear when the flag is off carries an unscoped `display: none` default:
+
+```css
+.filter-bar { display: none; }                    /* legacy default */
+
+:root[data-redesign='on'] .filter-bar,
+body.redesign-enabled .filter-bar { display: flex; /* … */ }
+```
+
+Hidden elements leave the accessibility tree, which is why Lighthouse (which
+audits flag-off pages) is unaffected by all of this.
+
+**JS.** Bootstraps return early unless the flag is on, and are guarded for Node
+so unit tests can import the module:
+
+```js
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.REDESIGN_FLAG || !window.REDESIGN_FLAG.isEnabled()) return;
+        initThing(document);
+    });
+}
+```
+
+---
+
+## 3. Public APIs
+
+### `window.NycCards` — `cards.js`
+```js
+buildEventCard(data, { type = 'popup' | 'date-idea' })  // → <a class="event-card">
+getCategoryTag(category)   // "🍕 Food & Drink"
+getVibeTag(vibe)           // "🌹 Romantic"
+getAreaLabel(neighborhood, borough)  // "SoHo, Manhattan"
+formatCardDate(start, end) // { dayName, dayNumber, monthYear, through }
+isFreePrice(price)
+```
+`data` is a **mapped** pop-up or date idea — the shape `mapSanityPopup` /
+`mapSanityDateIdea` produce (`name`, `start_datetime`, `category`, `venue_name`,
+`price`, `is_featured`, `img`, `short_desc`, …), not a raw Sanity document.
+
+### `window.NycModal` — `modal.js`
+```js
+openDetailModal(data, { type, returnLabel })  // → { close(), element }
+buildGoogleCalendarUrl(data)  // '' when the entry has no date
+getShareData(data, { type, origin })
+formatDetailDateTime(start, end)
+```
+The modal owns focus trapping, Escape / return-bar / overlay dismissal, focus
+restoration and the scroll lock. Callers own the data.
+
+### `window.NycFilters` — `filters.js` (set on bootstrap)
+```js
+getState()                       // { borough: null, type: 'market', … }
+setFilter(filter, value, label)  // external setter; null clears
+setResultsCount(n)               // usually unnecessary — see below
+```
+The results count already observes its container and reports what is rendered,
+so page code normally does not call `setResultsCount`.
+
+### `window.NycDatePicker` — `date-picker.js`
+```js
+initDatePicker(document, chip, panel, { onApply, onClear })
+```
+Mounted automatically by `filters.js` when a `.filter-dropdown--dates` panel
+exists. The pure helpers (`getMonthGrid`, `selectRangeDate`, `formatRangeLabel`,
+`toRangeValue`) are exported for reuse.
+
+---
+
+## 4. Events published
+
+Components announce state rather than reaching into each other. Epic 4 subscribes.
+
+| Event | Fired by | `detail` |
+|---|---|---|
+| `viewtoggle:change` | `search.js` | `{ view: 'list' \| 'map' }` |
+| `search:change` | `search.js` | `{ query }` (trimmed, collapsed, lowercased) |
+| `filters:change` | `filters.js` | `{ state, pageType }` |
+
+The active view is also reflected as `data-view` on `<html>`, so CSS can respond
+without JS. The date range appears in `filters:change` as `state.dates`, either
+`"2026-07-15"` or `"2026-07-15..2026-07-22"`.
+
+**Nothing consumes these yet.** #295 wires search and filter state to results,
+#296 renders the list, #297 the modal flow, #299 the map.
+
+---
+
+## 5. Deviations from REDESIGN.md
+
+Recorded so they are not re-litigated:
+
+- **Interior pages** (`interior.css`, #293) — §7 specs Pop-Ups, Date Ideas and
+  Home only. The About/Contact/Privacy shell is **derived from the design
+  system**, not from a mock. Adjust `interior.css` if one lands.
+- **View toggle is List/Map**, not List/Map/Calendar. §6.2 specifies two
+  buttons; the Calendar view belongs to Epic 5.
+- **Date ideas have no date filter.** §7.2 gives them Vibe/Budget/Neighborhood;
+  they are evergreen. The picker is page-agnostic and mounts wherever a dates
+  chip exists.
+- **`.filter-chip__chevron`**, not the spec's `.filter-chip .chevron` — Stylelint
+  enforces a BEM class pattern.
+- **Cards still render two-across** because `.popups-grid` keeps its legacy
+  `minmax(480px, 1fr)`. §6.4 wants single-column stacking; that is #294's job,
+  and it also resolves the search bar not lining up with the cards.
+
+---
+
+## 6. Traps worth knowing
+
+Each of these cost a debugging cycle during Epic 3.
+
+**Classic scripts share one global lexical scope.** A duplicate top-level
+`const` in any file silently kills that whole file — `cards.js` once declared
+`EASTERN_TIMEZONE`, which `pop-ups.js` already had, and nothing rendered. New
+modules are wrapped in an IIFE exposing a single `window.NycX`. An e2e test
+asserts every redesign page loads with zero page errors.
+
+**`buttons.css` styles the bare `button` selector** with the legacy pink palette
+and `padding: 8px 32px`, at a specificity that beats the `.ui-*` primitives. It
+turned filter chips fuchsia on hover and blew date-picker cells out to 80px.
+Components currently restate their own colours and padding to defend against it.
+Tracked in **#372**, which should land before the flag is switched on.
+
+**Date-only strings shift a day.** `new Date('2026-07-25')` is UTC midnight —
+the previous evening in Eastern time — so all-day events render a day early.
+Anchor date-only values at **noon UTC**, as `prebuild-events.js`, `cards.js` and
+`modal.js` all do.
+
+---
+
+## 7. Testing conventions
+
+- **CSS** is unit-tested by reading the file and regex-asserting tokens and
+  selectors (`expectCssToMatch`, see `tests/unit/design-system-foundation.spec.js`).
+- **Pure JS** is unit-tested directly; modules export via a `module.exports`
+  guard inside the IIFE.
+- **Behaviour** is tested in Playwright against `?redesign=on`, with a companion
+  assertion that the component is invisible flag-off.
+- **Colour assertions must await transitions.** `getComputedStyle` right after a
+  hover or class change samples a mid-fade blend, which silently makes
+  assertions pass:
+
+  ```js
+  await el.evaluate(async (node) => {
+    await Promise.all(node.getAnimations().map((a) => a.finished))
+    return getComputedStyle(node).backgroundColor
+  })
+  ```
+  Assert `el.matches(':hover')` too, so a hover that never applied fails loudly
+  instead of passing vacuously.
+- The in-app browser preview **freezes CSS transitions while its pane is
+  backgrounded**; measure colours in Playwright, not there.


### PR DESCRIPTION
Documentation only — no behaviour change. Suite still green at 240 unit + 104 e2e.

Epic 3 shipped seven shared components that **nothing wires up yet** — #294–#299 will consume all of them. The conventions they follow were worked out through debugging during the epic and were written down nowhere, so the next round would have rediscovered them the same way.

## `docs/redesign-components.md` (new)
The reference Epic 4 needs:
- **Inventory** — which CSS/JS file provides what, and its global
- **The gating contract** — both halves, and why a component doing only one leaks into the legacy experience
- **Public APIs** — `NycCards.buildEventCard`, `NycModal.openDetailModal`, `NycFilters.setFilter/getState`, `NycDatePicker.initDatePicker`, including that card/modal data is the *mapped* shape, not a raw Sanity document
- **Events published** — `viewtoggle:change`, `search:change`, `filters:change` with payloads, and which issue consumes each
- **Deviations from REDESIGN.md** — List/Map not List/Map/Calendar, no date filter on date ideas, `.filter-chip__chevron` for Stylelint, the derived interior shell, and why cards still render two-across
- **Traps**, each of which cost a debugging cycle: classic scripts sharing one global lexical scope (a duplicate `const` silently killed a whole file), `buttons.css` styling bare `button` (#372), and date-only strings shifting a day
- **Testing conventions**, including why colour assertions must await `getAnimations()` — two of mine passed vacuously by sampling mid-transition

## `CLAUDE.md`
A short section pointing at the above and restating the rules most likely to bite, plus a testing line under coding conventions.

## `REDESIGN.md`
§9 listed three CSS files; it is now five plus the gated additions to `hero.css` and `modals.css`, each row carrying status and issue. New §7.4 records what the derived interior-page shell actually is, so it is not re-litigated when someone notices there was never a mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)