### PR TITLE
Build the redesigned Pop-Ups page shell (#294)

### DIFF
--- a/pop-ups.html
+++ b/pop-ups.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="resources/css/filters.css">
     <link rel="stylesheet" href="resources/css/cards.css">
     <link rel="stylesheet" href="resources/css/popups.css">
+    <link rel="stylesheet" href="resources/css/popups-redesign.css">
     <link rel="stylesheet" href="resources/css/modals.css">
     <link rel="stylesheet" href="resources/css/footer.css">
     <!-- Removed broken style.css link -->
@@ -129,11 +130,17 @@
             <p class="results-count" aria-live="polite">0 events found</p>
             <hr class="ui-divider results-divider">
 
-            <!-- Pop-up Tiles Grid -->
-            <section class="popups-grid" id="popupsGrid">
-                <!-- STATIC_POPUPS_START -->
-                <!-- STATIC_POPUPS_END -->
-            </section>
+            <!-- Results region. The list panel is the legacy grid, restyled by
+                 popups-redesign.css when the flag is on; the map panel is empty
+                 until #299. search.js reflects the toggle onto <html data-view>,
+                 which is what swaps them. -->
+            <div class="results">
+                <section class="popups-grid results__panel results__panel--list" id="popupsGrid">
+                    <!-- STATIC_POPUPS_START -->
+                    <!-- STATIC_POPUPS_END -->
+                </section>
+                <div class="results__panel results__panel--map" id="popupsMap" role="region" aria-label="Map of pop-ups"></div>
+            </div>
             <script src="resources/js/pop-ups.js"></script>
         </main>
 

--- a/resources/css/popups-redesign.css
+++ b/resources/css/popups-redesign.css
@@ -1,0 +1,81 @@
+/* -----------------------------------------------------------------------------
+  POP-UPS PAGE SHELL (redesign only)
+  The results region that sits below the filter bar: a single-column list of
+  event cards, and the map panel #299 fills in. Legacy tile and grid rules stay
+  in popups.css; nothing here applies with the flag off.
+  See REDESIGN.md sections 6.4 and 7.1.
+----------------------------------------------------------------------------- */
+
+/* Flag-off defaults. The list panel is deliberately absent from this pair: it
+   is the legacy .popups-grid, and the prebuilt static tiles have to stay
+   visible without JS. */
+.results__panel--map,
+.results-divider {
+  display: none;
+}
+
+/* The region carries the width and gutter for both panels, matching
+   .search-bar-container and .filter-bar so all three share an edge. */
+:root[data-redesign='on'] .results,
+body.redesign-enabled .results {
+  max-width: var(--container-max-width);
+  margin-inline: auto;
+  padding: var(--space-sm) var(--space-sm-md) var(--space-lg);
+}
+
+/* popups.css sets section#popupsGrid's padding at !important, and an id beats
+   any number of stacked classes, so the shell cannot simply out-specify it.
+   Deleting the legacy rule would change the flag-off page below 975px — its
+   !important quietly outranks the media queries there too — so the padding is
+   handed back to the region instead. */
+:root[data-redesign='on'] section#popupsGrid,
+body.redesign-enabled section#popupsGrid {
+  padding: 0 !important;
+}
+
+/* Cards stack in one column up to --container-max-width. See section 6.4. */
+:root[data-redesign='on'] .results__panel--list,
+body.redesign-enabled .results__panel--list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
+}
+
+/* Aligned to the card edges rather than the viewport. */
+:root[data-redesign='on'] .results-divider,
+body.redesign-enabled .results-divider {
+  display: block;
+  max-width: calc(var(--container-max-width) - (2 * var(--space-sm-md)));
+  margin-inline: auto;
+}
+
+/* View switching ----------------------------------------------------------- */
+
+/* search.js reflects the toggle onto <html data-view>, so the panels follow it
+   without either side knowing about the other. */
+:root[data-redesign='on'][data-view='map'] .results__panel--list,
+:root[data-view='map'] body.redesign-enabled .results__panel--list {
+  display: none;
+}
+
+:root[data-redesign='on'][data-view='map'] .results__panel--map,
+:root[data-view='map'] body.redesign-enabled .results__panel--map {
+  display: block;
+}
+
+@media (max-width: 600px) {
+  :root[data-redesign='on'] .results,
+  body.redesign-enabled .results {
+    padding-inline: var(--space-sm);
+  }
+
+  :root[data-redesign='on'] .results__panel--list,
+  body.redesign-enabled .results__panel--list {
+    gap: var(--space-xs);
+  }
+
+  :root[data-redesign='on'] .results-divider,
+  body.redesign-enabled .results-divider {
+    max-width: calc(100% - (2 * var(--space-sm)));
+  }
+}

--- a/tests/e2e/redesign-popups-shell.spec.js
+++ b/tests/e2e/redesign-popups-shell.spec.js
@@ -1,0 +1,196 @@
+const { test, expect } = require('@playwright/test')
+
+const POPUPS = [
+  {
+    id: 'flavia-lounge',
+    name: 'Flavia Flavor Lounge',
+    start_datetime: '2026-07-23T15:00:00.000Z',
+    end_datetime: '2026-07-24T23:00:00.000Z',
+    category: 'food_drink',
+    venue_name: '22 Wooster',
+    neighborhood: 'SoHo',
+    borough: 'manhattan',
+    price: 'Free',
+    short_desc: 'Sip complimentary coffee and tea and match a drink to your mood.',
+    img: 'resources/images/images/default-popup-image.webp',
+  },
+  {
+    id: 'chelsea-night-market',
+    name: 'Chelsea Night Market',
+    start_datetime: '2026-07-25T22:00:00.000Z',
+    category: 'market',
+    venue_name: 'Chelsea Piers',
+    neighborhood: 'Chelsea',
+    borough: 'manhattan',
+    price: '$15',
+    short_desc: 'Forty vendors, live music and a skyline view after dark.',
+    img: 'resources/images/images/default-popup-image.webp',
+  },
+  {
+    id: 'bushwick-vintage',
+    name: 'Bushwick Vintage Fair',
+    start_datetime: '2026-08-01T14:00:00.000Z',
+    category: 'vintage_thrift',
+    venue_name: 'The Sultan Room',
+    neighborhood: 'Bushwick',
+    borough: 'brooklyn',
+    price: 'Free',
+    short_desc: 'Racks of archive denim, band tees and 70s glassware.',
+    img: 'resources/images/images/default-popup-image.webp',
+  },
+]
+
+/** Renders the fixture cards into the list panel and returns their locator. */
+async function renderCards(page, popups = POPUPS) {
+  await page.evaluate((data) => {
+    const grid = document.getElementById('popupsGrid')
+    grid.innerHTML = ''
+    for (const popup of data) {
+      grid.appendChild(window.NycCards.buildEventCard(popup, { type: 'popup' }))
+    }
+  }, popups)
+  return page.locator('.event-card')
+}
+
+test('the shell loads with no page errors', async ({ page }) => {
+  const errors = []
+  page.on('pageerror', (error) => errors.push(error.message))
+
+  await page.goto('/pop-ups.html?redesign=on')
+
+  expect(errors).toEqual([])
+})
+
+test('cards stack in a single column instead of two across', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto('/pop-ups.html?redesign=on')
+  const cards = await renderCards(page)
+
+  await expect(cards).toHaveCount(3)
+
+  const boxes = await cards.evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const rect = node.getBoundingClientRect()
+      return { top: Math.round(rect.top), left: Math.round(rect.left), width: Math.round(rect.width) }
+    })
+  )
+
+  // One column: every card shares a left edge and width, and each sits below
+  // the last. Two-across would pair them on a row.
+  expect(new Set(boxes.map((box) => box.left)).size).toBe(1)
+  expect(new Set(boxes.map((box) => box.width)).size).toBe(1)
+  expect(boxes[0].top).toBeLessThan(boxes[1].top)
+  expect(boxes[1].top).toBeLessThan(boxes[2].top)
+})
+
+for (const width of [1440, 1024, 768]) {
+  test(`cards line up with the search bar and filter bar at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 })
+    await page.goto('/pop-ups.html?redesign=on')
+    await renderCards(page)
+
+    const edges = await page.evaluate(() => {
+      // Inner edges of an element — where its children actually start and stop.
+      const inner = (selector) => {
+        const element = document.querySelector(selector)
+        const rect = element.getBoundingClientRect()
+        const computed = getComputedStyle(element)
+        return {
+          left: rect.left + parseFloat(computed.paddingLeft),
+          right: rect.right - parseFloat(computed.paddingRight),
+        }
+      }
+      const card = document.querySelector('.event-card').getBoundingClientRect()
+      return {
+        search: inner('.search-bar-container'),
+        filters: inner('.filter-bar'),
+        card: { left: card.left, right: card.right },
+      }
+    })
+
+    expect(Math.abs(edges.card.left - edges.search.left)).toBeLessThanOrEqual(1)
+    expect(Math.abs(edges.card.right - edges.search.right)).toBeLessThanOrEqual(1)
+    expect(Math.abs(edges.card.left - edges.filters.left)).toBeLessThanOrEqual(1)
+    expect(Math.abs(edges.card.right - edges.filters.right)).toBeLessThanOrEqual(1)
+  })
+}
+
+test('the results region never overflows the container width', async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 900 })
+  await page.goto('/pop-ups.html?redesign=on')
+  await renderCards(page)
+
+  const { cardWidth, containerMax } = await page.evaluate(() => ({
+    cardWidth: document.querySelector('.event-card').getBoundingClientRect().width,
+    containerMax: parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue('--container-max-width')
+    ),
+  }))
+
+  expect(cardWidth).toBeLessThanOrEqual(containerMax)
+})
+
+test('the map panel stays hidden until the toggle asks for it', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+
+  // The map panel is an empty container until #299 fills it, so assert on the
+  // display the shell controls rather than on rendered size.
+  const panels = () =>
+    page.evaluate(() => ({
+      view: document.documentElement.getAttribute('data-view'),
+      list: getComputedStyle(document.querySelector('.results__panel--list')).display,
+      map: getComputedStyle(document.querySelector('.results__panel--map')).display,
+    }))
+
+  expect(await panels()).toEqual({ view: 'list', list: 'grid', map: 'none' })
+
+  await page.getByRole('button', { name: 'Map' }).click()
+  expect(await panels()).toEqual({ view: 'map', list: 'none', map: 'block' })
+
+  await page.getByRole('button', { name: 'List' }).click()
+  expect(await panels()).toEqual({ view: 'list', list: 'grid', map: 'none' })
+})
+
+test('the results divider is part of the redesign only', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+  await expect(page.locator('.results-divider')).toBeVisible()
+
+  await page.goto('/pop-ups.html?redesign=off')
+  await expect(page.locator('.results-divider')).toBeHidden()
+  await expect(page.locator('.results__panel--map')).toBeHidden()
+  await expect(page.locator('.search-bar-container')).toBeHidden()
+  await expect(page.locator('.filter-bar')).toBeHidden()
+})
+
+test('the legacy grid keeps its own layout with the flag off', async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=off')
+
+  // #popupsGrid:empty zeroes the padding, so measure a populated grid.
+  await page.evaluate(() => {
+    const grid = document.getElementById('popupsGrid')
+    grid.innerHTML = '<a class="popup-tile popup-tile--horizontal"><div class="popup-tile__details"><h3>Tile</h3></div></a>'
+  })
+
+  // Baseline captured from the page before this issue touched it. section#popupsGrid
+  // sets padding at !important and outranks every media query, so the legacy grid
+  // is 16px on all sides at every width.
+  for (const [width, expected] of [
+    [1440, { columns: 2, padding: ['16px', '16px'] }],
+    [900, { columns: 1, padding: ['16px', '16px'] }],
+    [600, { columns: 1, padding: ['16px', '16px'] }],
+  ]) {
+    await page.setViewportSize({ width, height: 900 })
+    const layout = await page.locator('#popupsGrid').evaluate((grid) => {
+      const computed = getComputedStyle(grid)
+      return {
+        tracks: computed.gridTemplateColumns.split(' ').length,
+        paddingTop: computed.paddingTop,
+        paddingLeft: computed.paddingLeft,
+      }
+    })
+
+    expect(layout.tracks, `column count at ${width}px`).toBe(expected.columns)
+    expect(layout.paddingTop, `padding-top at ${width}px`).toBe(expected.padding[0])
+    expect(layout.paddingLeft, `padding-left at ${width}px`).toBe(expected.padding[1])
+  }
+})

--- a/tests/unit/popups-shell.spec.js
+++ b/tests/unit/popups-shell.spec.js
@@ -1,0 +1,102 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+function expectCssToMatch(css, pattern) {
+  const regexSpecialCharacters = new Set(['\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|'])
+  const escapedPattern = [...pattern]
+    .map((character) => (regexSpecialCharacters.has(character) ? `\\${character}` : character))
+    .join('')
+  expect(css).toMatch(new RegExp(escapedPattern.replaceAll(/\s+/g, '\\s*')))
+}
+
+describe('pop-ups results region styles', () => {
+  const css = read('resources/css/popups-redesign.css')
+
+  it('leaves the legacy grid alone until the flag is on', () => {
+    expectCssToMatch(css, ":root[data-redesign='on'] .results__panel--list")
+    expectCssToMatch(css, 'body.redesign-enabled .results__panel--list')
+  })
+
+  it('stacks cards in a single column up to the shared container width', () => {
+    expectCssToMatch(css, 'grid-template-columns: 1fr;')
+    expectCssToMatch(css, 'max-width: var(--container-max-width);')
+    expectCssToMatch(css, 'margin-inline: auto;')
+  })
+
+  it('shares the gutter the search and filter bars use, so the edges line up', () => {
+    // .search-bar-container and .filter-bar both pad their inline edges by
+    // --space-sm-md; the results list has to match or the cards sit inboard.
+    expectCssToMatch(css, 'var(--space-sm-md)')
+  })
+
+  it('swaps panels from the data-view attribute the toggle stamps on <html>', () => {
+    expectCssToMatch(css, "[data-view='map']")
+  })
+})
+
+describe('redesign-only shell elements are hidden with the flag off', () => {
+  const css = read('resources/css/popups-redesign.css').replaceAll(/\/\*[\s\S]*?\*\//g, '')
+
+  it.each(['.results__panel--map', '.results-divider'])('%s carries an unscoped display: none default', (selector) => {
+    const hidesUnscoped = css.split('}').some((block) => {
+      const [selectorPart, declarations = ''] = block.split('{')
+      if (!selectorPart || !declarations) return false
+      const targetsSelector = selectorPart
+        .split(',')
+        .map((one) => one.trim())
+        .includes(selector)
+      return targetsSelector && /display:\s*none/.test(declarations)
+    })
+
+    expect(hidesUnscoped, `${selector} needs a flag-off default of display: none`).toBe(true)
+  })
+})
+
+describe('pop-ups.html shell markup', () => {
+  const html = read('pop-ups.html')
+
+  it('links the shell stylesheet', () => {
+    expect(html).toContain('resources/css/popups-redesign.css')
+  })
+
+  it('wraps the grid in a results region holding a list panel and a map panel', () => {
+    expect(html).toMatch(/<div class="results"[^>]*>/)
+    expect(html).toMatch(/class="[^"]*results__panel--list[^"]*"[^>]*id="popupsGrid"/)
+    expect(html).toMatch(/class="[^"]*results__panel--map[^"]*"/)
+  })
+
+  it('keeps the grid element the page scripts and prebuild target', () => {
+    // prebuild-events.js injects between the markers; pop-ups.js and the
+    // Epic 3 e2e helpers look the grid up by id.
+    expect(html).toMatch(/id="popupsGrid"/)
+    const listPanel = html.slice(html.indexOf('results__panel--list'), html.indexOf('results__panel--map'))
+    expect(listPanel).toContain('<!-- STATIC_POPUPS_START -->')
+    expect(listPanel).toContain('<!-- STATIC_POPUPS_END -->')
+  })
+})
+
+describe('legacy pop-ups grid', () => {
+  it('is left intact, and the shell overrides its !important padding head-on', () => {
+    // section#popupsGrid sets padding at !important and outranks even the
+    // media queries, so the legacy grid is 16px on all sides at every width.
+    // Deleting it would change the flag-off page below 975px, so the gated
+    // rule matches it with !important instead — the same move popups.css
+    // already makes for section.popups-grid's margin and background.
+    expect(read('resources/css/popups.css')).toMatch(/section#popupsGrid/)
+
+    const shell = read('resources/css/popups-redesign.css')
+    const gatedPadding = shell
+      .split('}')
+      .filter((block) => /padding[^;]*!important/.test(block))
+    expect(gatedPadding.length).toBeGreaterThan(0)
+    for (const block of gatedPadding) {
+      expect(block).toMatch(/data-redesign='on'|redesign-enabled/)
+    }
+  })
+})


### PR DESCRIPTION
Closes #294.

Wires `pop-ups.html` into the Epic 3 shared components with a real results region. Everything is behind the redesign flag, which stays OFF in every environment — append `?redesign=on` to see it.

## What changed

- **New `resources/css/popups-redesign.css`** — the results region: single-column card list up to `--container-max-width`, sharing the 24px inline gutter that `.search-bar-container` and `.filter-bar` already use.
- **`pop-ups.html`** — the grid is now wrapped in `.results` with two panels: `.results__panel--list` (the existing `#popupsGrid`, so prebuild markers and `pop-ups.js` are untouched) and an empty `.results__panel--map` for #299. `search.js` already reflects the toggle onto `<html data-view>`, so the panels swap with no new JS.

## Leftovers this clears

Both were recorded in `docs/redesign-components.md` §5:

- Cards rendered two-across because `.popups-grid` kept its legacy `minmax(480px, 1fr)`.
- The search bar did not line up with the cards. Search bar, filter chips, results count, divider and cards now all span 144…1296 at 1440px.

## Two cascade findings

- **`section#popupsGrid` cannot simply be deleted.** It sets `padding` at `!important`, and because it is an id it outranks the media queries in the same file — so the legacy grid is 16px on all sides at *every* width, not the `0 16px` the media queries appear to specify. Removing it would have changed the flag-off page below 975px, so the shell matches it with a scoped override instead. An e2e test pins the flag-off geometry at 1440/900/600.
- **`.results-divider` had no flag-off default.** `.ui-divider` only sets a border, so the `<hr>` computed to `display: block` with the flag off — invisible today only because the grid is empty, and a stray full-width rule on the legacy page as soon as it is not. Now gated with the rest.

## Tests

Written first, watched fail, then made to pass.

- `tests/unit/popups-shell.spec.js` (10) — gating contract, single-column tokens, shared gutter, flag-off defaults, shell markup, and that the prebuild markers stay inside the list panel.
- `tests/e2e/redesign-popups-shell.spec.js` (9) — cards stack rather than pair; card edges match the search bar and filter bar within 1px at 1440/1024/768; panels swap on the toggle; divider is redesign-only; legacy grid geometry unchanged with the flag off.

Full suite: 250 unit, 113 e2e, Stylelint and HTMLHint all green.

## Not in this PR

- Month-group headings and empty/loading states — #296, alongside the rendering that produces them.
- The map itself — #299; the panel is deliberately an empty container.
- Card height is currently driven by the source image's aspect ratio, which single-column stacking makes more visible. Raised separately — it is a `cards.css` issue and REDESIGN.md does not specify a card height or image ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
