### PR TITLE
Wire Pop-Ups search and filter state to the results (#295)

### DIFF
--- a/docs/redesign-components.md
+++ b/docs/redesign-components.md
@@ -87,10 +87,32 @@ restoration and the scroll lock. Callers own the data.
 ```js
 getState()                       // { borough: null, type: 'market', … }
 setFilter(filter, value, label)  // external setter; null clears
+setOptions(filter, options)      // replace a dropdown's options from data
 setResultsCount(n)               // usually unnecessary — see below
 ```
 The results count already observes its container and reports what is rendered,
 so page code normally does not call `setResultsCount`.
+
+`setOptions` takes `[{ value, label }]`, keeps the leading "All …" row, and
+drops a selection the new data no longer offers. #295 uses it to build the
+Neighborhood list from the loaded pop-ups so the options cannot drift from the
+content. Every dropdown leads with an **"All …" option carrying an empty
+value**, which `selectOption` reads as clearing the filter.
+
+### `window.NycPopupsFilter` — `popups-filter.js` (pop-ups page only)
+```js
+createFilterController(doc, { onChange })  // → { getState(), apply(entries) }
+filterPopups(entries, state)
+matchesFilters(entry, state)
+matchesQuery(entry, query)      // name, venue_name, neighborhood
+parseDateRange(value)           // "2026-07-15" | "2026-07-15..2026-07-22"
+overlapsRange(entry, range)
+getDistinctNeighborhoods(entries)
+```
+Merges `search:change` and `filters:change` into one state object and decides
+*what* shows; the page still owns rendering. Date ranges match on **overlap**,
+so a multi-day run surfaces for any range touching it. Recurring events match
+only their base span — nothing on the site expands recurrence into occurrences.
 
 ### `window.NycDatePicker` — `date-picker.js`
 ```js
@@ -111,13 +133,20 @@ Components announce state rather than reaching into each other. Epic 4 subscribe
 | `viewtoggle:change` | `search.js` | `{ view: 'list' \| 'map' }` |
 | `search:change` | `search.js` | `{ query }` (trimmed, collapsed, lowercased) |
 | `filters:change` | `filters.js` | `{ state, pageType }` |
+| `filters:clear` | `filters.js` | — (Clear all was pressed) |
 
 The active view is also reflected as `data-view` on `<html>`, so CSS can respond
 without JS. The date range appears in `filters:change` as `state.dates`, either
 `"2026-07-15"` or `"2026-07-15..2026-07-22"`.
 
-**Nothing consumes these yet.** #295 wires search and filter state to results,
-#296 renders the list, #297 the modal flow, #299 the map.
+`filters:clear` fires *before* the accompanying `filters:change` and exists so
+Clear all can reset controls the filter bar does not own — `search.js` listens
+for it and empties the search box. Keeping it an event rather than a direct
+call is what stops the two modules depending on each other.
+
+**Consumed by:** `popups-filter.js` (#295) merges `search:change` and
+`filters:change` into the pop-ups result set. Still unconsumed:
+`viewtoggle:change`, which #299 needs for the map.
 
 ---
 
@@ -135,9 +164,12 @@ Recorded so they are not re-litigated:
   chip exists.
 - **`.filter-chip__chevron`**, not the spec's `.filter-chip .chevron` — Stylelint
   enforces a BEM class pattern.
-- **Cards still render two-across** because `.popups-grid` keeps its legacy
-  `minmax(480px, 1fr)`. §6.4 wants single-column stacking; that is #294's job,
-  and it also resolves the search bar not lining up with the cards.
+- **Dropdowns lead with an "All …" option** carrying an empty value (#295),
+  per §6.3. Epic 3 shipped without one, so clearing a single filter meant
+  re-selecting the active option — a gesture nobody discovers.
+- ~~**Cards still render two-across**~~ — resolved by #294. The results region
+  in `popups-redesign.css` stacks them to `--container-max-width` and aligns
+  them with the search and filter bars.
 
 ---
 
@@ -156,6 +188,15 @@ and `padding: 8px 32px`, at a specificity that beats the `.ui-*` primitives. It
 turned filter chips fuchsia on hover and blew date-picker cells out to 80px.
 Components currently restate their own colours and padding to defend against it.
 Tracked in **#372**, which should land before the flag is switched on.
+
+**`section#popupsGrid` in `popups.css` sets padding at `!important`**, and an
+id outranks any stack of classes, so a gated rule cannot out-specify it however
+many selectors you pile on. It also outranks the media queries in its own file,
+which means the legacy grid is 16px on all sides at *every* width — not the
+`0 16px` those blocks appear to specify. Deleting it therefore changes the
+flag-off page below 975px. `popups-redesign.css` neutralises it with one
+matching override instead. Cost a cycle in #294; the lesson generalises to any
+`#id` rule in the legacy stylesheets.
 
 **Date-only strings shift a day.** `new Date('2026-07-25')` is UTC midnight —
 the previous evening in Eastern time — so all-day events render a day early.

--- a/pop-ups.html
+++ b/pop-ups.html
@@ -35,6 +35,7 @@
         <script src="resources/js/search.js" defer></script>
         <script src="resources/js/date-picker.js" defer></script>
         <script src="resources/js/filters.js" defer></script>
+        <script src="resources/js/popups-filter.js" defer></script>
         <script src="resources/js/cards.js" defer></script>
         <script src="resources/js/modal.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
@@ -81,6 +82,7 @@
                         <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
                     </button>
                     <ul class="filter-dropdown" role="listbox" aria-label="Borough" hidden>
+                        <li class="filter-dropdown__option" role="option" aria-selected="true" data-value="" data-label="All Boroughs">All Boroughs</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="manhattan" data-label="Manhattan">Manhattan</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="brooklyn" data-label="Brooklyn">Brooklyn</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="queens" data-label="Queens">Queens</li>
@@ -94,7 +96,11 @@
                         <span class="filter-chip__label">Neighborhood</span>
                         <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
                     </button>
+                    <!-- Options past "All" are replaced at runtime from the loaded
+                         pop-ups, so the list cannot drift from the content. These
+                         are the no-JS fallback. -->
                     <ul class="filter-dropdown" role="listbox" aria-label="Neighborhood" hidden>
+                        <li class="filter-dropdown__option" role="option" aria-selected="true" data-value="" data-label="All Neighborhoods">All Neighborhoods</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Chelsea" data-label="Chelsea">Chelsea</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="East Village" data-label="East Village">East Village</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="Lower East Side" data-label="Lower East Side">Lower East Side</li>
@@ -108,6 +114,7 @@
                         <span class="filter-chip__chevron" aria-hidden="true">&#9662;</span>
                     </button>
                     <ul class="filter-dropdown" role="listbox" aria-label="Type" hidden>
+                        <li class="filter-dropdown__option" role="option" aria-selected="true" data-value="" data-label="All Types">All Types</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="food_drink" data-label="Food &amp; Drink">&#127829; Food &amp; Drink</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="market" data-label="Market">&#128717; Market</li>
                         <li class="filter-dropdown__option" role="option" aria-selected="false" data-value="art_culture" data-label="Art &amp; Culture">&#127912; Art &amp; Culture</li>

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -32,13 +32,15 @@ function createFilterState(filters) {
 
 /**
  * Selects a value for a filter. Choosing the value that is already selected
- * clears it, so a chip can be toggled off without reaching for Clear all.
- * Unknown filters are ignored. Returns a new object.
+ * clears it, so a chip can be toggled off without reaching for Clear all. The
+ * "All …" option carries an empty value and always clears. Unknown filters are
+ * ignored. Returns a new object.
  */
 function selectOption(state, filter, value) {
     if (!Object.prototype.hasOwnProperty.call(state, filter)) return { ...state };
     const next = { ...state };
-    next[filter] = next[filter] === value ? null : value;
+    const chosen = value === '' || value === undefined ? null : value;
+    next[filter] = next[filter] === chosen ? null : chosen;
     return next;
 }
 
@@ -135,7 +137,11 @@ function initFilters(doc) {
             const selectedOption = options.find(option => option.dataset.value === selected);
 
             options.forEach(option => {
-                option.setAttribute('aria-selected', String(option.dataset.value === selected));
+                // With nothing chosen the "All …" row is the selection, so the
+                // listbox always has exactly one selected option.
+                const isAll = option.dataset.value === '';
+                const isSelected = selected ? option.dataset.value === selected : isAll;
+                option.setAttribute('aria-selected', String(isSelected));
             });
 
             // A group with no options (the date picker) supplies its own
@@ -178,11 +184,13 @@ function initFilters(doc) {
 
         if (!dropdown) return;
 
-        const options = Array.from(dropdown.querySelectorAll('[role="option"]'));
+        // Read live: setOptions can replace the list after the data loads, and
+        // a captured array would leave the keyboard walking detached nodes.
+        const getOptions = () => Array.from(dropdown.querySelectorAll('[role="option"]'));
 
         // Options are focusable programmatically only; arrow keys move a
         // roving focus through them, per the listbox pattern.
-        options.forEach(option => {
+        getOptions().forEach(option => {
             option.tabIndex = -1;
         });
 
@@ -193,11 +201,12 @@ function initFilters(doc) {
             chip.focus();
         }
 
-        options.forEach(option => {
+        getOptions().forEach(option => {
             option.addEventListener('click', () => choose(option));
         });
 
         group.addEventListener('keydown', event => {
+            const options = getOptions();
             const index = options.indexOf(event.target);
             const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp';
 
@@ -226,6 +235,9 @@ function initFilters(doc) {
         clearButton.addEventListener('click', () => {
             state = clearAll(state);
             closeAll(null);
+            // Announced separately from filters:change so the search box can
+            // reset itself without this module reaching into it.
+            bar.dispatchEvent(new CustomEvent('filters:clear', { bubbles: true }));
             render();
         });
     }
@@ -269,6 +281,52 @@ function initFilters(doc) {
     return {
         getState: () => ({ ...state }),
         setResultsCount,
+        /**
+         * Replaces a dropdown's options with ones derived from the loaded
+         * data, so the list cannot drift from the content. The leading
+         * "All …" row is kept, and a selection that survives the rebuild is
+         * kept too — a refetch should not silently drop the active filter.
+         */
+        setOptions: (filter, options) => {
+            const group = Array.from(bar.querySelectorAll('.filter-bar__group')).find(
+                candidate => {
+                    const chip = candidate.querySelector('.filter-chip');
+                    return chip && chip.dataset.filter === filter;
+                }
+            );
+            if (!group) return;
+            const dropdown = group.querySelector('.filter-dropdown');
+            if (!dropdown) return;
+
+            const allOption = dropdown.querySelector('[role="option"][data-value=""]');
+            dropdown.replaceChildren();
+            if (allOption) dropdown.appendChild(allOption);
+
+            for (const { value, label } of options) {
+                const option = doc.createElement('li');
+                option.className = 'filter-dropdown__option';
+                option.setAttribute('role', 'option');
+                option.setAttribute('aria-selected', 'false');
+                option.tabIndex = -1;
+                option.dataset.value = value;
+                option.dataset.label = label;
+                option.textContent = label;
+                option.addEventListener('click', () => {
+                    state = selectOption(state, filter, option.dataset.value);
+                    render();
+                    closeDropdown(group.querySelector('.filter-chip'), dropdown);
+                    group.querySelector('.filter-chip').focus();
+                });
+                dropdown.appendChild(option);
+            }
+
+            // Drop a selection the new data no longer offers.
+            const values = new Set(options.map(option => option.value));
+            if (state[filter] && !values.has(state[filter])) {
+                state = { ...state, [filter]: null };
+            }
+            render();
+        },
         /**
          * Sets a filter from outside the bar — used by the date picker, whose
          * chip has no option list of its own. Passing a null value clears it.

--- a/resources/js/pop-ups.js
+++ b/resources/js/pop-ups.js
@@ -646,12 +646,36 @@ function loadAndDisplayPopups() {
 
             const grid = document.getElementById('popupsGrid');
             if (!grid) return;
-            grid.innerHTML = '';
 
-            popups.forEach(popup => {
-                const tile = createPopupTile(popup);
-                if (tile) grid.appendChild(tile);
-            });
+            function renderPopups(list) {
+                grid.innerHTML = '';
+                list.forEach(popup => {
+                    const tile = createPopupTile(popup);
+                    if (tile) grid.appendChild(tile);
+                });
+            }
+
+            // With the redesign on, the search box and filter chips drive the
+            // rendered set. Flag-off pages render everything, as before.
+            const redesignOn = Boolean(window.REDESIGN_FLAG && window.REDESIGN_FLAG.isEnabled());
+            if (redesignOn && window.NycPopupsFilter) {
+                const controller = window.NycPopupsFilter.createFilterController(document, {
+                    onChange: state => renderPopups(window.NycPopupsFilter.filterPopups(popups, state)),
+                });
+
+                // The neighborhood list comes from the content rather than a
+                // hardcoded set, so no event is unreachable by that filter.
+                if (window.NycFilters && window.NycFilters.setOptions) {
+                    window.NycFilters.setOptions(
+                        'neighborhood',
+                        window.NycPopupsFilter.getDistinctNeighborhoods(popups)
+                    );
+                }
+
+                renderPopups(controller.apply(popups));
+            } else {
+                renderPopups(popups);
+            }
 
             // Inject JSON-LD for CollectionPage + ItemList of pop-ups
             // Only do this on the pop-ups.html listing page

--- a/resources/js/popups-filter.js
+++ b/resources/js/popups-filter.js
@@ -1,0 +1,172 @@
+// Filter and search state for the redesigned Pop-Ups page. Subscribes to the
+// `search:change` and `filters:change` events the shared components publish
+// and reduces them to one predicate over the mapped pop-up list. Rendering
+// stays with the page — this module decides *what* shows, not how.
+// See REDESIGN.md sections 6.2/6.3 and docs/redesign-components.md.
+//
+// Wrapped in an IIFE: classic scripts share one global lexical scope, and a
+// duplicate top-level declaration silently kills a whole file.
+(function (global) {
+    'use strict';
+
+    // === CONSTANTS ===
+
+    /** Fields the search box looks at, matching what its placeholder promises. */
+    const SEARCH_FIELDS = ['name', 'venue_name', 'neighborhood'];
+
+    const EASTERN_ZONE = 'America/New_York';
+
+    const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+    const RANGE_SEPARATOR = '..';
+
+    // === PURE HELPERS ===
+
+    /**
+     * Date-only strings are anchored at noon UTC. `new Date('2026-07-25')` is
+     * UTC midnight — the previous evening in Eastern time — which renders and
+     * filters all-day events a day early.
+     */
+    function toDate(value) {
+        if (!value) return null;
+        const raw = String(value);
+        const parsed = DATE_ONLY.test(raw) ? new Date(`${raw}T12:00:00.000Z`) : new Date(raw);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    /**
+     * The calendar day an instant falls on in New York, as YYYY-MM-DD. Ranges
+     * are day-granular, so comparing days rather than instants keeps an event
+     * at 6pm on the last day of a range inside it.
+     */
+    function toDayKey(date) {
+        if (!date) return null;
+        return date.toLocaleDateString('en-CA', { timeZone: EASTERN_ZONE });
+    }
+
+    /** Reads "2026-07-15" or "2026-07-15..2026-07-22". Returns null if unusable. */
+    function parseDateRange(value) {
+        if (!value) return null;
+        const [rawFrom, rawTo] = String(value).split(RANGE_SEPARATOR);
+        if (!DATE_ONLY.test(rawFrom || '')) return null;
+        if (rawTo !== undefined && !DATE_ONLY.test(rawTo)) return null;
+
+        const from = toDate(rawFrom);
+        const to = toDate(rawTo || rawFrom);
+        if (!from || !to) return null;
+        return from <= to ? { from, to } : { from: to, to: from };
+    }
+
+    /**
+     * True when any part of the entry falls inside the range. A month-long
+     * installation should surface for a range anywhere inside its run, not
+     * only for the week it opened. Undated entries drop out of a dated search.
+     */
+    function overlapsRange(entry, range) {
+        if (!range) return true;
+        if (!entry) return false;
+
+        const start = toDate(entry.start_datetime);
+        if (!start) return false;
+        const end = toDate(entry.end_datetime) || start;
+
+        const startDay = toDayKey(start);
+        const endDay = toDayKey(end);
+        return startDay <= toDayKey(range.to) && endDay >= toDayKey(range.from);
+    }
+
+    /** Case-insensitive substring match across the searchable fields. */
+    function matchesQuery(entry, query) {
+        const needle = String(query == null ? '' : query).trim().toLowerCase();
+        if (!needle) return true;
+        if (!entry) return false;
+
+        return SEARCH_FIELDS.some((field) => {
+            const value = entry[field];
+            return typeof value === 'string' && value.toLowerCase().includes(needle);
+        });
+    }
+
+    /** The "All …" option carries an empty value, which reads as unset. */
+    function isSet(value) {
+        return value !== null && value !== undefined && value !== '';
+    }
+
+    function matchesFilters(entry, state) {
+        if (!state) return true;
+        if (!entry) return false;
+
+        if (!matchesQuery(entry, state.query)) return false;
+        if (isSet(state.borough) && entry.borough !== state.borough) return false;
+        if (isSet(state.neighborhood) && entry.neighborhood !== state.neighborhood) return false;
+        if (isSet(state.type) && entry.category !== state.type) return false;
+        if (isSet(state.dates) && !overlapsRange(entry, parseDateRange(state.dates))) return false;
+        return true;
+    }
+
+    function filterPopups(entries, state) {
+        const list = Array.isArray(entries) ? entries : [];
+        if (!state) return list.slice();
+        return list.filter((entry) => matchesFilters(entry, state));
+    }
+
+    /**
+     * The neighborhoods actually present in the data, so the dropdown cannot
+     * drift from the content or hide events behind a stale option list.
+     */
+    function getDistinctNeighborhoods(entries) {
+        const seen = new Map();
+        for (const entry of Array.isArray(entries) ? entries : []) {
+            const name = entry && typeof entry.neighborhood === 'string' ? entry.neighborhood.trim() : '';
+            if (name && !seen.has(name)) seen.set(name, { value: name, label: name });
+        }
+        return [...seen.values()].sort((a, b) =>
+            a.label.localeCompare(b.label, 'en', { sensitivity: 'base' })
+        );
+    }
+
+    // === DOM WIRING ===
+
+    /**
+     * Merges the two event streams into one state object and reports every
+     * change. The components stay unaware of each other; this is the only
+     * place that knows a query and a set of chips describe one result set.
+     */
+    function createFilterController(doc, { onChange } = {}) {
+        let state = { query: '', borough: null, neighborhood: null, type: null, dates: null };
+
+        function publish() {
+            if (typeof onChange === 'function') onChange({ ...state });
+        }
+
+        doc.addEventListener('search:change', (event) => {
+            state = { ...state, query: (event.detail && event.detail.query) || '' };
+            publish();
+        });
+
+        doc.addEventListener('filters:change', (event) => {
+            const incoming = (event.detail && event.detail.state) || {};
+            state = { ...state, ...incoming };
+            publish();
+        });
+
+        return {
+            getState: () => ({ ...state }),
+            apply: (entries) => filterPopups(entries, state),
+        };
+    }
+
+    const api = {
+        SEARCH_FIELDS,
+        matchesQuery,
+        matchesFilters,
+        filterPopups,
+        parseDateRange,
+        overlapsRange,
+        getDistinctNeighborhoods,
+        createFilterController,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (global) global.NycPopupsFilter = api;
+})(typeof window !== 'undefined' ? window : null);

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -92,18 +92,28 @@ function initSearchBar(doc) {
         reflectView(doc, currentView);
     }
 
+    function publishQuery() {
+        container.dispatchEvent(
+            new CustomEvent('search:change', {
+                bubbles: true,
+                detail: { query: normalizeSearchInput(input.value) },
+            })
+        );
+    }
+
     if (input) {
-        input.addEventListener('input', () => {
-            container.dispatchEvent(
-                new CustomEvent('search:change', {
-                    bubbles: true,
-                    detail: { query: normalizeSearchInput(input.value) },
-                })
-            );
+        input.addEventListener('input', publishQuery);
+
+        // "Clear all" means all of it. The filter bar announces the reset
+        // rather than calling in here, so neither module depends on the other.
+        doc.addEventListener('filters:clear', () => {
+            if (input.value === '') return;
+            input.value = '';
+            publishQuery();
         });
     }
 
-    return { getView: () => currentView };
+    return { getView: () => currentView, clearQuery: () => { if (input) { input.value = ''; publishQuery(); } } };
 }
 
 // === BOOTSTRAP ===

--- a/tests/e2e/redesign-filters.spec.js
+++ b/tests/e2e/redesign-filters.spec.js
@@ -104,6 +104,10 @@ test('a keyboard user can open a filter and select an option', async ({ page }) 
   await page.keyboard.press('Enter')
   await expect(page.getByRole('listbox', { name: 'Borough' })).toBeVisible()
 
+  // The list opens on "All Boroughs", so a real borough is one step further.
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('option', { name: 'All Boroughs' })).toBeFocused()
+
   await page.keyboard.press('ArrowDown')
   await expect(page.getByRole('option', { name: 'Manhattan' })).toBeFocused()
 
@@ -120,7 +124,11 @@ test('arrow keys move through the options and wrap around', async ({ page }) => 
   await boroughChip(page).focus()
   await page.keyboard.press('Enter')
 
+  // Order is All Boroughs, Manhattan, Brooklyn, … Citywide.
   await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('option', { name: 'Manhattan' })).toBeFocused()
+
   await page.keyboard.press('ArrowDown')
   await expect(page.getByRole('option', { name: 'Brooklyn' })).toBeFocused()
 
@@ -129,11 +137,13 @@ test('arrow keys move through the options and wrap around', async ({ page }) => 
 
   // Wrapping backwards from the first option lands on the last.
   await page.keyboard.press('ArrowUp')
+  await expect(page.getByRole('option', { name: 'All Boroughs' })).toBeFocused()
+  await page.keyboard.press('ArrowUp')
   await expect(page.getByRole('option', { name: 'Citywide' })).toBeFocused()
 
   // And forwards from the last wraps to the first.
   await page.keyboard.press('ArrowDown')
-  await expect(page.getByRole('option', { name: 'Manhattan' })).toBeFocused()
+  await expect(page.getByRole('option', { name: 'All Boroughs' })).toBeFocused()
 })
 
 test('Space selects the focused option', async ({ page }) => {
@@ -141,7 +151,8 @@ test('Space selects the focused option', async ({ page }) => {
 
   await typeChip(page).focus()
   await page.keyboard.press('Enter')
-  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('ArrowDown') // All Types
+  await page.keyboard.press('ArrowDown') // Food & Drink
   await page.keyboard.press(' ')
 
   await expect(page.getByRole('button', { name: /^Food & Drink/ })).toHaveClass(/filter-chip--active/)
@@ -152,7 +163,8 @@ test('the keyboard-focused option is visibly indicated', async ({ page }) => {
 
   await boroughChip(page).focus()
   await page.keyboard.press('Enter')
-  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('ArrowDown') // All Boroughs
+  await page.keyboard.press('ArrowDown') // Manhattan
 
   const indicator = await page.getByRole('option', { name: 'Manhattan' }).evaluate((el) => {
     const computed = getComputedStyle(el)

--- a/tests/e2e/redesign-popups-filtering.spec.js
+++ b/tests/e2e/redesign-popups-filtering.spec.js
@@ -1,0 +1,226 @@
+const { test, expect } = require('@playwright/test')
+
+/** Raw Sanity documents, i.e. what the GROQ query returns before mapping. */
+const DOCUMENTS = [
+  {
+    _id: 'flavia',
+    slug: 'flavia',
+    name: 'Flavia Flavor Lounge',
+    start_datetime: '2026-07-23T15:00:00Z',
+    end_datetime: '2026-07-24T23:00:00Z',
+    category: 'food_drink',
+    borough: 'manhattan',
+    neighborhood: 'SoHo',
+    venue_name: '22 Wooster',
+    price: 'Free',
+    short_description: 'Complimentary coffee and tea in a loft space.',
+    display_overall: true,
+    display_in_popups_page: true,
+  },
+  {
+    _id: 'chelsea',
+    slug: 'chelsea',
+    name: 'Chelsea Night Market',
+    start_datetime: '2026-08-15T22:00:00Z',
+    end_datetime: '2026-08-16T04:00:00Z',
+    category: 'market',
+    borough: 'manhattan',
+    neighborhood: 'Chelsea',
+    venue_name: 'Chelsea Piers',
+    price: '$15',
+    short_description: 'Forty vendors and live music after dark.',
+    display_overall: true,
+    display_in_popups_page: true,
+  },
+  {
+    _id: 'bushwick',
+    slug: 'bushwick',
+    name: 'Bushwick Vintage Fair',
+    start_datetime: '2026-09-05T14:00:00Z',
+    end_datetime: '2026-09-05T20:00:00Z',
+    category: 'vintage_thrift',
+    borough: 'brooklyn',
+    neighborhood: 'Bushwick',
+    venue_name: 'The Sultan Room',
+    price: 'Free',
+    short_description: 'Archive denim, band tees and 70s glassware.',
+    display_overall: true,
+    display_in_popups_page: true,
+  },
+  {
+    _id: 'astoria',
+    slug: 'astoria',
+    name: 'Astoria Beer Garden Sessions',
+    start_datetime: '2026-09-12T18:00:00Z',
+    end_datetime: '2026-09-12T23:00:00Z',
+    category: 'music',
+    borough: 'queens',
+    neighborhood: 'Astoria',
+    venue_name: 'Bohemian Hall',
+    price: '$10',
+    short_description: 'Live sets under the trees.',
+    display_overall: true,
+    display_in_popups_page: true,
+  },
+]
+
+test.beforeEach(async ({ page }) => {
+  await page.route('https://41kk82h2.apicdn.sanity.io/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ result: DOCUMENTS }),
+    })
+  )
+})
+
+/** Names currently rendered in the results grid, in order. */
+async function renderedNames(page) {
+  return page.locator('#popupsGrid .popup-tile__details h3').allTextContents()
+}
+
+async function gotoPopups(page, { flag = 'on' } = {}) {
+  await page.goto(`/pop-ups.html?redesign=${flag}`)
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(DOCUMENTS.length)
+}
+
+/** Opens a chip's dropdown and picks the option with the given label. */
+async function chooseFilter(page, filter, label) {
+  await page.locator(`.filter-chip[data-filter="${filter}"]`).click()
+  await page.locator(`.filter-bar__group [role="option"][data-label="${label}"]`).click()
+}
+
+test('search narrows the results to matching events', async ({ page }) => {
+  await gotoPopups(page)
+
+  await page.locator('.search-bar__input').fill('chelsea')
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(1)
+  expect(await renderedNames(page)).toEqual(['Chelsea Night Market'])
+
+  // Venue and neighborhood are searchable too, not just the name.
+  await page.locator('.search-bar__input').fill('wooster')
+  expect(await renderedNames(page)).toEqual(['Flavia Flavor Lounge'])
+
+  await page.locator('.search-bar__input').fill('bushwick')
+  expect(await renderedNames(page)).toEqual(['Bushwick Vintage Fair'])
+})
+
+test('the results count follows the filtered set', async ({ page }) => {
+  await gotoPopups(page)
+  await expect(page.locator('.results-count')).toHaveText('4 events found')
+
+  await page.locator('.search-bar__input').fill('chelsea')
+  await expect(page.locator('.results-count')).toHaveText('1 event found')
+
+  await page.locator('.search-bar__input').fill('nothing matches this')
+  await expect(page.locator('.results-count')).toHaveText('0 events found')
+})
+
+test('chips filter the results and combine with each other', async ({ page }) => {
+  await gotoPopups(page)
+
+  await chooseFilter(page, 'borough', 'Manhattan')
+  expect(await renderedNames(page)).toEqual(['Flavia Flavor Lounge', 'Chelsea Night Market'])
+
+  await chooseFilter(page, 'type', 'Market')
+  expect(await renderedNames(page)).toEqual(['Chelsea Night Market'])
+
+  // A combination with no matches is empty rather than falling back to all.
+  await chooseFilter(page, 'borough', 'Brooklyn')
+  expect(await renderedNames(page)).toEqual([])
+})
+
+test('a chip reflects its selection and clears from the All option', async ({ page }) => {
+  await gotoPopups(page)
+
+  const chip = page.locator('.filter-chip[data-filter="borough"]')
+  await expect(chip).not.toHaveClass(/filter-chip--active/)
+
+  await chooseFilter(page, 'borough', 'Queens')
+  await expect(chip.locator('.filter-chip__label')).toHaveText('Queens')
+  await expect(chip).toHaveClass(/filter-chip--active/)
+  expect(await renderedNames(page)).toEqual(['Astoria Beer Garden Sessions'])
+
+  await chooseFilter(page, 'borough', 'All Boroughs')
+  await expect(chip.locator('.filter-chip__label')).toHaveText('Borough')
+  await expect(chip).not.toHaveClass(/filter-chip--active/)
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+})
+
+test('the neighborhood options come from the loaded data', async ({ page }) => {
+  await gotoPopups(page)
+
+  const options = await page
+    .locator('.filter-chip[data-filter="neighborhood"] ~ .filter-dropdown [role="option"]')
+    .allTextContents()
+
+  // Astoria and Bushwick are in the data but not in the page's static list;
+  // Williamsburg and East Village are in the static list but not the data.
+  expect(options).toEqual(['All Neighborhoods', 'Astoria', 'Bushwick', 'Chelsea', 'SoHo'])
+
+  await chooseFilter(page, 'neighborhood', 'Astoria')
+  expect(await renderedNames(page)).toEqual(['Astoria Beer Garden Sessions'])
+})
+
+test('the date range filters on overlap and clears again', async ({ page }) => {
+  await gotoPopups(page)
+
+  await page.evaluate(() => {
+    window.NycFilters.setFilter('dates', '2026-08-01..2026-08-31', 'Aug 1 – Aug 31')
+  })
+  expect(await renderedNames(page)).toEqual(['Chelsea Night Market'])
+
+  await page.evaluate(() => window.NycFilters.setFilter('dates', null))
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+})
+
+test('Clear all resets the chips and the search box together', async ({ page }) => {
+  await gotoPopups(page)
+
+  await page.locator('.search-bar__input').fill('chelsea')
+  await chooseFilter(page, 'borough', 'Manhattan')
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(1)
+
+  const clear = page.locator('.filter-bar__clear')
+  await expect(clear).toBeVisible()
+  await clear.click()
+
+  await expect(page.locator('.search-bar__input')).toHaveValue('')
+  await expect(page.locator('.filter-chip[data-filter="borough"] .filter-chip__label')).toHaveText('Borough')
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+  await expect(clear).toBeHidden()
+})
+
+test('filtering works the same on a phone', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await gotoPopups(page)
+
+  await chooseFilter(page, 'type', 'Music')
+  expect(await renderedNames(page)).toEqual(['Astoria Beer Garden Sessions'])
+
+  await page.locator('.filter-bar__clear').click()
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+})
+
+test('the flag-off page renders everything and ignores the controls', async ({ page }) => {
+  await gotoPopups(page, { flag: 'off' })
+
+  await expect(page.locator('.search-bar-container')).toBeHidden()
+  await expect(page.locator('.filter-bar')).toBeHidden()
+
+  // Publishing the events the hidden controls would have sent must not
+  // re-render the legacy page.
+  await page.evaluate(() => {
+    document.dispatchEvent(new CustomEvent('search:change', { detail: { query: 'chelsea' } }))
+  })
+  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+})
+
+test('the page loads with no errors once filtering is wired', async ({ page }) => {
+  const errors = []
+  page.on('pageerror', (error) => errors.push(error.message))
+
+  await gotoPopups(page)
+
+  expect(errors).toEqual([])
+})

--- a/tests/unit/filters.spec.js
+++ b/tests/unit/filters.spec.js
@@ -78,6 +78,22 @@ describe('filter state', () => {
     expect(original.borough).toBeNull()
   })
 
+  it("clears the filter when the All option's empty value is chosen", () => {
+    // "All Boroughs" carries data-value="", which has to read as unset rather
+    // than as a value of its own — otherwise Clear all stays visible and the
+    // predicate filters on an empty string.
+    let state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'bronx')
+    state = selectOption(state, 'borough', '')
+    expect(state.borough).toBeNull()
+    expect(isAnyActive(state)).toBe(false)
+  })
+
+  it('leaves an already-clear filter clear when All is chosen', () => {
+    const state = selectOption(createFilterState(FILTER_SETS.popups), 'type', '')
+    expect(state.type).toBeNull()
+    expect(isAnyActive(state)).toBe(false)
+  })
+
   it('clears one filter and leaves the rest alone', () => {
     let state = selectOption(createFilterState(FILTER_SETS.popups), 'borough', 'bronx')
     state = selectOption(state, 'type', 'beauty')
@@ -225,5 +241,25 @@ describe('filter markup', () => {
       expect(html).toContain('<link rel="stylesheet" href="resources/css/filters.css">')
       expect(html).toContain('<script src="resources/js/filters.js" defer></script>')
     }
+  })
+
+  it('leads each pop-ups dropdown with an All option that clears the filter', () => {
+    // REDESIGN.md 6.3 lists "All Neighborhoods" / "All Types" as options.
+    // The empty value is what selectOption reads as unset.
+    for (const [filter, label] of [
+      ['borough', 'All Boroughs'],
+      ['neighborhood', 'All Neighborhoods'],
+      ['type', 'All Types'],
+    ]) {
+      const listStart = popupsHtml.indexOf(`data-filter="${filter}"`)
+      const list = popupsHtml.slice(listStart, popupsHtml.indexOf('</ul>', listStart))
+      const firstOption = list.slice(list.indexOf('role="option"'))
+      expect(firstOption, `${filter} dropdown`).toContain('data-value=""')
+      expect(firstOption, `${filter} dropdown`).toContain(label)
+    }
+  })
+
+  it('links the pop-ups filter state module', () => {
+    expect(popupsHtml).toContain('<script src="resources/js/popups-filter.js" defer></script>')
   })
 })

--- a/tests/unit/popups-filter.spec.js
+++ b/tests/unit/popups-filter.spec.js
@@ -1,0 +1,215 @@
+const {
+  matchesQuery,
+  matchesFilters,
+  filterPopups,
+  parseDateRange,
+  overlapsRange,
+  getDistinctNeighborhoods,
+} = require('../../resources/js/popups-filter.js')
+
+/** A mapped pop-up, i.e. what mapSanityPopup produces. */
+function popup(overrides = {}) {
+  return {
+    id: 'flavia-lounge',
+    name: 'Flavia Flavor Lounge',
+    start_datetime: '2026-07-23T15:00:00.000Z',
+    end_datetime: '2026-07-24T23:00:00.000Z',
+    category: 'food_drink',
+    borough: 'manhattan',
+    neighborhood: 'SoHo',
+    venue_name: '22 Wooster',
+    short_desc: 'Complimentary coffee and tea in a loft space.',
+    ...overrides,
+  }
+}
+
+const NO_FILTERS = { query: '', borough: null, neighborhood: null, type: null, dates: null }
+
+describe('matchesQuery', () => {
+  it('matches the event name, venue and neighborhood', () => {
+    expect(matchesQuery(popup(), 'flavia')).toBe(true)
+    expect(matchesQuery(popup(), 'wooster')).toBe(true)
+    expect(matchesQuery(popup(), 'soho')).toBe(true)
+  })
+
+  it('ignores case and surrounding whitespace', () => {
+    expect(matchesQuery(popup(), '  FLAVIA  ')).toBe(true)
+  })
+
+  it('does not match on the description', () => {
+    // The placeholder promises events, venues and neighborhoods. Matching body
+    // copy makes the result set feel arbitrary.
+    expect(matchesQuery(popup(), 'complimentary')).toBe(false)
+  })
+
+  it('treats an empty query as matching everything', () => {
+    expect(matchesQuery(popup(), '')).toBe(true)
+    expect(matchesQuery(popup(), null)).toBe(true)
+  })
+
+  it('rejects a query that matches nothing', () => {
+    expect(matchesQuery(popup(), 'brooklyn')).toBe(false)
+  })
+
+  it('survives entries with missing fields', () => {
+    expect(matchesQuery({ name: 'Only a name' }, 'name')).toBe(true)
+    expect(matchesQuery({}, 'anything')).toBe(false)
+  })
+})
+
+describe('parseDateRange', () => {
+  it('reads a single date as a one-day range', () => {
+    const range = parseDateRange('2026-07-15')
+    expect(range.from.toISOString()).toBe('2026-07-15T12:00:00.000Z')
+    expect(range.to.toISOString()).toBe('2026-07-15T12:00:00.000Z')
+  })
+
+  it('reads a two-ended range', () => {
+    const range = parseDateRange('2026-07-15..2026-07-22')
+    expect(range.from.toISOString()).toBe('2026-07-15T12:00:00.000Z')
+    expect(range.to.toISOString()).toBe('2026-07-22T12:00:00.000Z')
+  })
+
+  it('anchors at noon UTC so an Eastern day is never off by one', () => {
+    // new Date('2026-07-15') is UTC midnight, i.e. the evening of the 14th in
+    // New York. Noon UTC keeps the calendar day intact on both sides.
+    const { from } = parseDateRange('2026-07-15')
+    const easternDay = from.toLocaleDateString('en-US', { timeZone: 'America/New_York', day: 'numeric' })
+    expect(easternDay).toBe('15')
+  })
+
+  it('returns null for absent or malformed values', () => {
+    expect(parseDateRange(null)).toBeNull()
+    expect(parseDateRange('')).toBeNull()
+    expect(parseDateRange('not-a-date')).toBeNull()
+  })
+})
+
+describe('overlapsRange', () => {
+  const range = parseDateRange('2026-07-20..2026-07-24')
+
+  it('includes an event running through the range', () => {
+    expect(overlapsRange(popup({ start_datetime: '2026-07-10T12:00:00.000Z', end_datetime: '2026-08-10T12:00:00.000Z' }), range)).toBe(true)
+  })
+
+  it('includes an event starting inside the range', () => {
+    expect(overlapsRange(popup({ start_datetime: '2026-07-23T15:00:00.000Z', end_datetime: '2026-07-30T23:00:00.000Z' }), range)).toBe(true)
+  })
+
+  it('includes an event ending inside the range', () => {
+    expect(overlapsRange(popup({ start_datetime: '2026-07-01T15:00:00.000Z', end_datetime: '2026-07-21T23:00:00.000Z' }), range)).toBe(true)
+  })
+
+  it('includes a single-day event on the range boundary', () => {
+    expect(overlapsRange(popup({ start_datetime: '2026-07-24T18:00:00.000Z', end_datetime: '' }), range)).toBe(true)
+    expect(overlapsRange(popup({ start_datetime: '2026-07-20T09:00:00.000Z', end_datetime: '' }), range)).toBe(true)
+  })
+
+  it('excludes events wholly before or after the range', () => {
+    expect(overlapsRange(popup({ start_datetime: '2026-07-01T15:00:00.000Z', end_datetime: '2026-07-05T23:00:00.000Z' }), range)).toBe(false)
+    expect(overlapsRange(popup({ start_datetime: '2026-08-01T15:00:00.000Z', end_datetime: '' }), range)).toBe(false)
+  })
+
+  it('treats a date-only all-day event as covering its whole day', () => {
+    // '2026-07-20' must not resolve to the evening of the 19th.
+    expect(overlapsRange(popup({ start_datetime: '2026-07-20', end_datetime: '2026-07-20' }), range)).toBe(true)
+    expect(overlapsRange(popup({ start_datetime: '2026-07-19', end_datetime: '2026-07-19' }), range)).toBe(false)
+  })
+
+  it('keeps undated entries out of a date-filtered set', () => {
+    expect(overlapsRange(popup({ start_datetime: '', end_datetime: '' }), range)).toBe(false)
+  })
+
+  it('matches everything when there is no range', () => {
+    expect(overlapsRange(popup(), null)).toBe(true)
+  })
+})
+
+describe('matchesFilters', () => {
+  it('passes an entry when nothing is set', () => {
+    expect(matchesFilters(popup(), NO_FILTERS)).toBe(true)
+  })
+
+  it.each([
+    ['borough', 'manhattan', 'brooklyn'],
+    ['neighborhood', 'SoHo', 'Chelsea'],
+    ['type', 'food_drink', 'market'],
+  ])('applies the %s filter', (filter, hit, miss) => {
+    expect(matchesFilters(popup(), { ...NO_FILTERS, [filter]: hit })).toBe(true)
+    expect(matchesFilters(popup(), { ...NO_FILTERS, [filter]: miss })).toBe(false)
+  })
+
+  it('requires every active filter to agree', () => {
+    const state = { ...NO_FILTERS, borough: 'manhattan', type: 'market' }
+    expect(matchesFilters(popup(), state)).toBe(false)
+    expect(matchesFilters(popup({ category: 'market' }), state)).toBe(true)
+  })
+
+  it('combines search with the chips', () => {
+    const state = { ...NO_FILTERS, query: 'flavia', borough: 'brooklyn' }
+    expect(matchesFilters(popup(), state)).toBe(false)
+  })
+
+  it('applies the date range alongside the chips', () => {
+    const state = { ...NO_FILTERS, dates: '2026-07-23..2026-07-24', type: 'food_drink' }
+    expect(matchesFilters(popup(), state)).toBe(true)
+    expect(matchesFilters(popup(), { ...state, dates: '2026-09-01' })).toBe(false)
+  })
+
+  it('treats an empty-string filter value as unset', () => {
+    // The "All …" option carries an empty value.
+    expect(matchesFilters(popup(), { ...NO_FILTERS, borough: '' })).toBe(true)
+  })
+})
+
+describe('filterPopups', () => {
+  const all = [
+    popup(),
+    popup({ id: 'chelsea-market', name: 'Chelsea Night Market', neighborhood: 'Chelsea', category: 'market' }),
+    popup({ id: 'bushwick-vintage', name: 'Bushwick Vintage Fair', borough: 'brooklyn', neighborhood: 'Bushwick', category: 'vintage_thrift' }),
+  ]
+
+  it('returns everything when no filter is active', () => {
+    expect(filterPopups(all, NO_FILTERS)).toHaveLength(3)
+  })
+
+  it('narrows to the matching entries and preserves order', () => {
+    const result = filterPopups(all, { ...NO_FILTERS, borough: 'manhattan' })
+    expect(result.map((entry) => entry.id)).toEqual(['flavia-lounge', 'chelsea-market'])
+  })
+
+  it('can return nothing', () => {
+    expect(filterPopups(all, { ...NO_FILTERS, query: 'nonexistent' })).toEqual([])
+  })
+
+  it('tolerates a missing state object', () => {
+    expect(filterPopups(all, undefined)).toHaveLength(3)
+  })
+})
+
+describe('getDistinctNeighborhoods', () => {
+  it('collects the neighborhoods present, sorted and deduped', () => {
+    const all = [
+      popup({ neighborhood: 'SoHo' }),
+      popup({ neighborhood: 'Chelsea' }),
+      popup({ neighborhood: 'SoHo' }),
+      popup({ neighborhood: 'Bushwick' }),
+    ]
+    expect(getDistinctNeighborhoods(all)).toEqual([
+      { value: 'Bushwick', label: 'Bushwick' },
+      { value: 'Chelsea', label: 'Chelsea' },
+      { value: 'SoHo', label: 'SoHo' },
+    ])
+  })
+
+  it('skips entries with no neighborhood', () => {
+    expect(getDistinctNeighborhoods([popup({ neighborhood: '' }), popup({ neighborhood: 'SoHo' })])).toEqual([
+      { value: 'SoHo', label: 'SoHo' },
+    ])
+  })
+
+  it('sorts case-insensitively', () => {
+    const all = [popup({ neighborhood: 'east village' }), popup({ neighborhood: 'Chelsea' })]
+    expect(getDistinctNeighborhoods(all).map((option) => option.value)).toEqual(['Chelsea', 'east village'])
+  })
+})


### PR DESCRIPTION
Closes #295.

Connects the search box, filter chips and date picker to the pop-ups result set. Behind the redesign flag; append `?redesign=on`.

## What changed

**New `resources/js/popups-filter.js`** (`window.NycPopupsFilter`) — subscribes to `search:change` and `filters:change`, merges them into one state object, and reduces that to a single predicate over the mapped pop-up list. The page keeps ownership of rendering, so #296 can swap tiles for cards without touching any of this.

**Two agreed changes to the shared filter bar**, both from questions raised before building:

- **Every dropdown leads with an "All …" option** carrying an empty value, per §6.3. Epic 3 shipped without one, so clearing a single filter meant re-selecting the active option — a gesture nobody discovers. `selectOption` now reads an empty value as unset, and the listbox always has exactly one selected row.
- **Neighborhood options are built from the loaded data** via a new `NycFilters.setOptions(filter, options)`. The page previously hardcoded five, so an event in any other neighborhood was unreachable by that filter. The static five stay in the markup as the no-JS fallback.

**Clear all now empties the search box too.** `filters.js` announces `filters:clear` and `search.js` resets itself — an event rather than a direct call, so the two modules stay independent, consistent with how the rest of Epic 3 is wired.

## Behaviour worth stating

- **Search covers name, venue and neighborhood** — what the placeholder promises. Deliberately not the description, which makes results feel arbitrary.
- **Date ranges match on overlap.** A month-long installation surfaces for any range touching its run, not only the week it opened.
- **Recurring events match their base span only.** Nothing on the site expands recurrence into occurrences — the calendar places events by their single start/end too — so this is consistent with existing behaviour rather than a new gap. Worth its own issue if it matters.

## Tests

- `tests/unit/popups-filter.spec.js` (33) — query matching, range parsing and noon-UTC anchoring, overlap at both boundaries, combined predicates, neighborhood derivation.
- `tests/e2e/redesign-popups-filtering.spec.js` (10) — search, chips, combinations that match nothing, the All option, data-derived neighborhoods, the date range, Clear all resetting both halves, a phone viewport, and the flag-off page ignoring the events entirely. Sanity is stubbed with `page.route`, following `detail-happy-path.spec.js`.
- The e2e tests were written after the implementation, so I mutation-checked them: breaking `matchesQuery`, `overlapsRange` and the borough predicate each fails exactly the tests that cover them and no others.
- `redesign-filters.spec.js` — four keyboard tests move one step down the list to account for the new leading option. Expectation change only; the behaviour they assert is unchanged.

Full suite: 287 unit, 123 e2e, Stylelint and HTMLHint green.

## Docs

`docs/redesign-components.md` updated: `NycPopupsFilter` and `setOptions` added to the API section, `filters:clear` added to the events table, "nothing consumes these yet" corrected, the resolved two-across deviation struck, and the `section#popupsGrid` specificity trap from #294 written up alongside the other traps.

## Not in this PR

Cards still render as legacy `.popup-tile`s — #296 swaps in `NycCards`. The card-height question from #294 is still open.

One thing to watch on #296: the results count observes `#popupsGrid.childElementCount`, so month-group headings will be counted as results once they exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
