### PR TITLE
Stop the source image dictating card height (#376)

### DIFF
--- a/resources/css/cards.css
+++ b/resources/css/cards.css
@@ -13,6 +13,9 @@ body.redesign-enabled .event-card {
   display: grid;
   grid-template-columns: 150px 35% 1fr;
   align-items: stretch;
+  /* The row is sized by its content now that the image is out of flow; this
+     stops an entry with no description shrinking the photo to a sliver. */
+  min-height: 200px;
   overflow: hidden;
   width: 100%;
   max-width: var(--container-max-width);
@@ -109,18 +112,26 @@ body.redesign-enabled .event-card__media {
   overflow: hidden;
 }
 
+/* Absolutely positioned so the photo contributes nothing to layout height.
+   `height: 100%` in an auto-height grid row has nothing to resolve against and
+   falls back to the image's intrinsic height, which made every card as tall as
+   whatever the editor uploaded — a 563x750 portrait produced a 538px card and a
+   1534px featured one. Taking it out of flow lets the row be sized by the date
+   and details columns, which is what 6.4's "fills full column height" means. */
 :root[data-redesign='on'] .event-card__image,
 body.redesign-enabled .event-card__image {
+  position: absolute;
+  inset: 0;
   display: block;
   width: 100%;
   height: 100%;
-  min-height: 180px;
   object-fit: cover;
 }
 
 :root[data-redesign='on'] .event-card__tag,
 body.redesign-enabled .event-card__tag {
   position: absolute;
+  z-index: 1;
   top: var(--space-xs);
   left: var(--space-xs);
   padding: 4px 10px;
@@ -191,8 +202,12 @@ body.redesign-enabled .event-card--featured {
   grid-template-columns: 1fr;
 }
 
-:root[data-redesign='on'] .event-card--featured .event-card__image,
-body.redesign-enabled .event-card--featured .event-card__image {
+/* The media column is the only in-flow child of a featured card, so it needs a
+   height of its own rather than borrowing the image's. A wide ratio keeps the
+   hero bounded — 16/9 would be 648px at the full container width. */
+:root[data-redesign='on'] .event-card--featured .event-card__media,
+body.redesign-enabled .event-card--featured .event-card__media {
+  aspect-ratio: 21 / 9;
   min-height: 320px;
 }
 
@@ -252,6 +267,12 @@ body.redesign-enabled .event-card--featured .event-card__date {
   :root[data-redesign='on'] .event-card,
   body.redesign-enabled .event-card {
     grid-template-columns: 1fr;
+  }
+
+  /* Stacked, so the media row has no column height to stretch into. */
+  :root[data-redesign='on'] .event-card__media,
+  body.redesign-enabled .event-card__media {
+    aspect-ratio: 16 / 9;
   }
 
   /* Date collapses to a bar above the image. */

--- a/tests/e2e/redesign-card-height.spec.js
+++ b/tests/e2e/redesign-card-height.spec.js
@@ -1,0 +1,147 @@
+const { test, expect } = require('@playwright/test')
+
+// Real files from the repo, chosen for their aspect ratios. The card's height
+// must not depend on which one an editor happens to upload.
+const IMAGES = {
+  portrait: '/resources/images/images/default-popup-image.webp', // 563x750
+  landscape: '/resources/images/banners/midtown_manhattan_skyline.webp', // 1920x1280
+  square: '/resources/images/images/profile.webp', // 256x256
+}
+
+const POPUP = {
+  id: 'flavia-lounge',
+  name: 'Flavia Flavor Lounge',
+  start_datetime: '2026-08-13T15:00:00.000Z',
+  end_datetime: '2026-08-14T23:00:00.000Z',
+  category: 'food_drink',
+  venue_name: '22 Wooster',
+  neighborhood: 'SoHo',
+  borough: 'manhattan',
+  price: 'Free',
+  short_desc: 'Sip complimentary coffee and tea and match a drink to your mood in a loft space built for lingering.',
+}
+
+/** Renders one card, waits for the image to decode, and measures it. */
+async function measureCard(page, { img, featured = false, data = POPUP }) {
+  return page.evaluate(
+    async ({ data, img, featured }) => {
+      const grid = document.getElementById('popupsGrid')
+      grid.innerHTML = ''
+      grid.appendChild(window.NycCards.buildEventCard({ ...data, img, is_featured: featured }, { type: 'popup' }))
+
+      const image = document.querySelector('.event-card__image')
+      if (image && !image.complete) {
+        await new Promise((resolve) => {
+          image.onload = resolve
+          image.onerror = resolve
+        })
+      }
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+
+      const card = document.querySelector('.event-card').getBoundingClientRect()
+      const media = document.querySelector('.event-card__media').getBoundingClientRect()
+      const rendered = image.getBoundingClientRect()
+      return {
+        card: Math.round(card.height),
+        media: Math.round(media.height),
+        image: { width: Math.round(rendered.width), height: Math.round(rendered.height) },
+        natural: [image.naturalWidth, image.naturalHeight],
+        objectFit: getComputedStyle(image).objectFit,
+      }
+    },
+    { data, img, featured }
+  )
+}
+
+for (const [width, label] of [[1440, 'desktop'], [800, 'tablet'], [390, 'mobile']]) {
+  test(`card height ignores the source image's aspect ratio on ${label}`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 1000 })
+    await page.goto('/pop-ups.html?redesign=on')
+
+    const heights = {}
+    for (const [name, img] of Object.entries(IMAGES)) {
+      heights[name] = (await measureCard(page, { img })).card
+    }
+
+    // A portrait upload must not produce a taller card than a landscape one.
+    expect(new Set(Object.values(heights)).size, `heights were ${JSON.stringify(heights)}`).toBe(1)
+  })
+
+  test(`featured card height ignores the source image's aspect ratio on ${label}`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 1000 })
+    await page.goto('/pop-ups.html?redesign=on')
+
+    const heights = {}
+    for (const [name, img] of Object.entries(IMAGES)) {
+      heights[name] = (await measureCard(page, { img, featured: true })).card
+    }
+
+    expect(new Set(Object.values(heights)).size, `heights were ${JSON.stringify(heights)}`).toBe(1)
+  })
+}
+
+test('a standard card stays close to the height of its own content', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const measured = await measureCard(page, { img: IMAGES.portrait })
+
+  // The three-column card is a compact row, not a panel. Its content — a date
+  // column and a title, three clamped description lines and two meta lines —
+  // needs roughly 200px.
+  expect(measured.card).toBeGreaterThanOrEqual(180)
+  expect(measured.card).toBeLessThanOrEqual(320)
+})
+
+test('a featured card is a bounded hero rather than a full page', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  const measured = await measureCard(page, { img: IMAGES.portrait, featured: true })
+
+  expect(measured.card).toBeGreaterThanOrEqual(320)
+  expect(measured.card).toBeLessThanOrEqual(600)
+})
+
+test('a sparse entry still gets a usable image area', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.goto('/pop-ups.html?redesign=on')
+
+  // No description and no end date: the details column has very little in it.
+  const measured = await measureCard(page, {
+    img: IMAGES.landscape,
+    data: { ...POPUP, short_desc: '', end_datetime: '' },
+  })
+
+  expect(measured.media).toBeGreaterThanOrEqual(150)
+})
+
+for (const [name, img] of Object.entries(IMAGES)) {
+  test(`the ${name} image covers its box without letterboxing`, async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    await page.goto('/pop-ups.html?redesign=on')
+
+    const measured = await measureCard(page, { img })
+
+    // The image fills the media column exactly; object-fit does the cropping.
+    expect(measured.objectFit).toBe('cover')
+    expect(Math.abs(measured.image.height - measured.media)).toBeLessThanOrEqual(1)
+  })
+}
+
+test('the category tag still sits above the image', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.goto('/pop-ups.html?redesign=on')
+  await measureCard(page, { img: IMAGES.portrait })
+
+  // Absolutely positioning the image must not bury the tag behind it.
+  const tag = page.locator('.event-card__tag')
+  await expect(tag).toBeVisible()
+
+  const onTop = await page.evaluate(() => {
+    const rect = document.querySelector('.event-card__tag').getBoundingClientRect()
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
+    return hit.closest('.event-card__tag') !== null
+  })
+  expect(onTop).toBe(true)
+})

--- a/tests/unit/cards.spec.js
+++ b/tests/unit/cards.spec.js
@@ -179,4 +179,24 @@ describe('card styles', () => {
   it('gives the featured variant a full-width image treatment', () => {
     expectCssToMatch(css, '.event-card--featured')
   })
+
+  it('takes the image out of flow so it cannot set the card height', () => {
+    // height: 100% in an auto grid row resolves to the intrinsic height, which
+    // made the card as tall as whatever was uploaded. See #376.
+    expectCssToMatch(css, 'position: absolute;')
+    expectCssToMatch(css, 'inset: 0;')
+    expectCssToMatch(css, 'object-fit: cover;')
+    expect(css).not.toMatch(/\.event-card__image[^}]*min-height/)
+  })
+
+  it('gives the media box a ratio wherever the grid supplies no height', () => {
+    // Featured cards and the stacked phone layout are single-column, so the
+    // media row has nothing to stretch into.
+    expectCssToMatch(css, 'aspect-ratio: 21 / 9;')
+    expectCssToMatch(css, 'aspect-ratio: 16 / 9;')
+  })
+
+  it('keeps a floor under the card so a sparse entry keeps a usable image', () => {
+    expectCssToMatch(css, 'min-height: 200px;')
+  })
 })


### PR DESCRIPTION
Closes #376.

`.event-card__image` set `width: 100%; height: 100%`, but in an auto-height grid row `height: 100%` has nothing to resolve against and falls back to the image's intrinsic height. The source image was therefore setting the card's height.

| | portrait 563×750 | landscape 1920×1280 | square 256×256 |
|---|---|---|---|
| standard @1440 | 538px | 270px | 405px |
| featured @1440 | **1534px** | 769px | 1152px |
| standard @390 | 730px | 493px | 612px |

`default-popup-image.webp` is the 563×750 portrait, so the featured variant was 1534px tall — taller than the viewport. Single-column stacking in #294 made this far more visible; it was masked while cards rendered two-across, because the image column was half the width.

## The fix

**The image is absolutely positioned inside `.event-card__media`**, so it contributes nothing to layout height. The three-column row is then sized by the date and details columns — which is what §6.4's "photo fills full column height, `object-fit: cover`" actually describes: the photo follows the card, rather than setting it.

**Two single-column contexts have no column height to stretch into**, so their media box needs an explicit ratio:

- **Featured** — `aspect-ratio: 21 / 9`, keeping the existing 320px floor. 16/9 would be 648px at the full container width, which is a lot of the page for one card.
- **Phones (<600px)** — `aspect-ratio: 16 / 9` on the stacked layout.

**A 200px `min-height` on the card** stops an entry with no description reducing the photo to a sliver.

Result — heights are now identical across all three source images:

| | standard | featured |
|---|---|---|
| @1440 | 202px | 495px |
| @800 | 232px | 322px |
| @390 | 456px | 371px |

## On the numbers I picked

REDESIGN.md specifies no card height and no image ratio, so `21 / 9`, `16 / 9` and `200px` are mine. The first two follow from bounding the hero and keeping a conventional ratio on phones; `200px` is roughly what the card's own content already needs, so it only bites on sparse entries. All three are single values in `cards.css` if you want them different — the structural part of the fix (image out of flow) is independent of them.

## Tests

Written first and watched fail: 6 of the 13 failed with the diagnostics above.

- `tests/e2e/redesign-card-height.spec.js` (13) — the core invariant is that card height is *identical* across three real images from the repo with different aspect ratios, checked for standard and featured at 1440/800/390. Plus: the standard card stays near its content height, the featured card is bounded, a sparse entry keeps a usable image area, the image still covers its box with no letterboxing, and the category tag still hit-tests above the now-absolute image.
- `tests/unit/cards.spec.js` — CSS assertions for the mechanism, including that `.event-card__image` no longer carries a `min-height`.

Full suite: 250 unit, 126 e2e, Stylelint and HTMLHint green.

## Note on scope

Branched from `staging`, so this is independent of the open #295 ([#375](https://github.com/anewbegin95/project-pizza/pull/375)) and can merge in either order. `cards.css` is shared, so date ideas get the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
