### PR TITLE
Render Pop-Ups list results as grouped event cards (#296)

### DIFF
--- a/pop-ups.html
+++ b/pop-ups.html
@@ -37,6 +37,7 @@
         <script src="resources/js/filters.js" defer></script>
         <script src="resources/js/popups-filter.js" defer></script>
         <script src="resources/js/cards.js" defer></script>
+        <script src="resources/js/popups-list.js" defer></script>
         <script src="resources/js/modal.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
         <!-- STATIC_JSONLD_START -->

--- a/resources/css/popups-redesign.css
+++ b/resources/css/popups-redesign.css
@@ -41,6 +41,60 @@ body.redesign-enabled .results__panel--list {
   gap: var(--space-sm);
 }
 
+/* Month groups (section 6.4) --------------------------------------------- */
+
+.event-group__heading,
+.results-empty {
+  display: none;
+}
+
+:root[data-redesign='on'] .event-group,
+body.redesign-enabled .event-group {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
+  margin: 0;
+  background: none;
+}
+
+/* Groups sit inside the list panel's own gap, so only later ones need space
+   above their heading. */
+:root[data-redesign='on'] .event-group + .event-group,
+body.redesign-enabled .event-group + .event-group {
+  margin-top: var(--space-md);
+}
+
+:root[data-redesign='on'] .event-group__heading,
+body.redesign-enabled .event-group__heading {
+  display: block;
+  padding-bottom: var(--space-xs);
+  border-bottom: 1px solid var(--nyc-section-divider);
+  color: var(--nyc-navy);
+  font-family: var(--nyc-font-display);
+  font-size: 40px;
+  font-weight: var(--font-weight-regular);
+}
+
+/* No results (derived — REDESIGN.md does not specify one) ------------------ */
+
+:root[data-redesign='on'] .results-empty,
+body.redesign-enabled .results-empty {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  align-items: center;
+  padding: var(--space-lg) var(--space-sm);
+  text-align: center;
+}
+
+:root[data-redesign='on'] .results-empty__message,
+body.redesign-enabled .results-empty__message {
+  margin: 0;
+  color: var(--nyc-charcoal);
+  font-family: var(--nyc-font-body);
+  font-size: var(--font-sm);
+}
+
 /* Aligned to the card edges rather than the viewport. */
 :root[data-redesign='on'] .results-divider,
 body.redesign-enabled .results-divider {
@@ -67,6 +121,11 @@ body.redesign-enabled .results-divider {
   :root[data-redesign='on'] .results,
   body.redesign-enabled .results {
     padding-inline: var(--space-sm);
+  }
+
+  :root[data-redesign='on'] .event-group__heading,
+  body.redesign-enabled .event-group__heading {
+    font-size: 28px;
   }
 
   :root[data-redesign='on'] .results__panel--list,

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -20,6 +20,13 @@ const RESULTS_CONTAINERS = {
     'date-ideas': '#dateIdeasGrid',
 };
 
+/**
+ * What counts as one result. Counting the container's children would be wrong
+ * once results are grouped by month (#296) — each child is then a group, not an
+ * event — and would count the no-results panel as a result.
+ */
+const RESULT_ITEM_SELECTOR = '.event-card, .popup-tile';
+
 // === PURE STATE HELPERS ===
 
 /** Builds an empty state object keyed by the page's filters. */
@@ -269,10 +276,12 @@ function initFilters(doc) {
     // reporting a stale zero.
     const resultsContainer = doc.querySelector(RESULTS_CONTAINERS[pageType] || '');
     if (resultsContainer && resultsCount) {
-        const syncCount = () => setResultsCount(resultsContainer.childElementCount);
+        const syncCount = () =>
+            setResultsCount(resultsContainer.querySelectorAll(RESULT_ITEM_SELECTOR).length);
         syncCount();
         if (typeof MutationObserver !== 'undefined') {
-            new MutationObserver(syncCount).observe(resultsContainer, { childList: true });
+            // subtree, because grouped results nest their cards inside sections.
+            new MutationObserver(syncCount).observe(resultsContainer, { childList: true, subtree: true });
         }
     }
 

--- a/resources/js/pop-ups.js
+++ b/resources/js/pop-ups.js
@@ -647,7 +647,23 @@ function loadAndDisplayPopups() {
             const grid = document.getElementById('popupsGrid');
             if (!grid) return;
 
+            // With the redesign on, the search box and filter chips drive the
+            // rendered set. Flag-off pages render everything, as before.
+            const redesignOn = Boolean(window.REDESIGN_FLAG && window.REDESIGN_FLAG.isEnabled());
+            const useCards = redesignOn && window.NycPopupsList && window.NycCards;
+
             function renderPopups(list) {
+                if (useCards) {
+                    // Month-grouped event cards, with a no-results state that
+                    // offers the way out. See REDESIGN.md section 6.4.
+                    window.NycPopupsList.renderResults(grid, list, {
+                        onClear: () => {
+                            const clear = document.querySelector('.filter-bar__clear');
+                            if (clear) clear.click();
+                        },
+                    });
+                    return;
+                }
                 grid.innerHTML = '';
                 list.forEach(popup => {
                     const tile = createPopupTile(popup);
@@ -655,9 +671,6 @@ function loadAndDisplayPopups() {
                 });
             }
 
-            // With the redesign on, the search box and filter chips drive the
-            // rendered set. Flag-off pages render everything, as before.
-            const redesignOn = Boolean(window.REDESIGN_FLAG && window.REDESIGN_FLAG.isEnabled());
             if (redesignOn && window.NycPopupsFilter) {
                 const controller = window.NycPopupsFilter.createFilterController(document, {
                     onChange: state => renderPopups(window.NycPopupsFilter.filterPopups(popups, state)),

--- a/resources/js/popups-list.js
+++ b/resources/js/popups-list.js
@@ -1,0 +1,166 @@
+// Result presentation for the redesigned Pop-Ups list: month grouping, the
+// shared event cards, and the no-results state. Deciding *which* entries show
+// is popups-filter.js; this only renders what it is handed.
+// See REDESIGN.md section 6.4.
+//
+// Wrapped in an IIFE: classic scripts share one global lexical scope, and a
+// duplicate top-level declaration silently kills a whole file.
+(function (global) {
+    'use strict';
+
+    // === CONSTANTS ===
+
+    const EASTERN_ZONE = 'America/New_York';
+
+    const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+    const EMPTY_MESSAGE = 'No pop-ups match these filters.';
+
+    const EMPTY_ACTION_LABEL = 'Clear all filters';
+
+    // === PURE HELPERS ===
+
+    /**
+     * Date-only strings are anchored at noon UTC. `new Date('2026-09-01')` is
+     * UTC midnight — the previous evening in Eastern time — which would file an
+     * all-day event under the previous month's heading.
+     */
+    function toDate(value) {
+        if (!value) return null;
+        const raw = String(value);
+        const parsed = DATE_ONLY.test(raw) ? new Date(`${raw}T12:00:00.000Z`) : new Date(raw);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    /** The 'YYYY-MM' an entry belongs to, in New York time. Null when undated. */
+    function getMonthKey(entry) {
+        const start = toDate(entry && entry.start_datetime);
+        if (!start) return null;
+        // en-CA gives YYYY-MM-DD, which slices cleanly and sorts lexicographically.
+        return start.toLocaleDateString('en-CA', { timeZone: EASTERN_ZONE }).slice(0, 7);
+    }
+
+    /** '2026-08' -> 'August 2026'. */
+    function formatMonthHeading(key) {
+        const [year, month] = String(key).split('-');
+        const date = new Date(Date.UTC(Number(year), Number(month) - 1, 1, 12));
+        return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+    }
+
+    /**
+     * Groups entries into chronological months. Entries keep their date order
+     * within a group — featured ones are not hoisted, matching the mock, where
+     * the featured card sits in the run rather than on top. A multi-month run
+     * appears once, under the month it starts in. Undated entries collect into
+     * a trailing group with no heading rather than being dropped.
+     */
+    function groupByMonth(entries) {
+        const list = Array.isArray(entries) ? entries.slice() : [];
+        const byKey = new Map();
+        const undated = [];
+
+        for (const entry of list) {
+            const key = getMonthKey(entry);
+            if (key === null) {
+                undated.push(entry);
+                continue;
+            }
+            if (!byKey.has(key)) byKey.set(key, []);
+            byKey.get(key).push(entry);
+        }
+
+        const groups = [...byKey.keys()]
+            .sort()
+            .map((key) => ({
+                key,
+                label: formatMonthHeading(key),
+                items: byKey.get(key).sort((a, b) => toDate(a.start_datetime) - toDate(b.start_datetime)),
+            }));
+
+        if (undated.length > 0) groups.push({ key: null, label: '', items: undated });
+        return groups;
+    }
+
+    // === DOM ===
+
+    function createElement(doc, tag, className, text) {
+        const element = doc.createElement(tag);
+        if (className) element.className = className;
+        if (text !== undefined) element.textContent = text;
+        return element;
+    }
+
+    /**
+     * The only dead end in the flow, so it offers the way out rather than
+     * leaving people to guess which of four filters to undo. The button asks
+     * the filter bar to clear, which also empties the search box (#295).
+     */
+    function buildEmptyState(doc, { onClear } = {}) {
+        const wrapper = createElement(doc, 'div', 'results-empty');
+        wrapper.setAttribute('role', 'status');
+        wrapper.appendChild(createElement(doc, 'p', 'results-empty__message', EMPTY_MESSAGE));
+
+        const button = createElement(doc, 'button', 'ui-btn ui-btn--primary results-empty__action', EMPTY_ACTION_LABEL);
+        button.type = 'button';
+        button.addEventListener('click', () => {
+            if (typeof onClear === 'function') onClear();
+        });
+        wrapper.appendChild(button);
+        return wrapper;
+    }
+
+    function buildGroup(doc, group, buildCard) {
+        const section = createElement(doc, 'section', 'event-group');
+
+        if (group.label) {
+            const heading = createElement(doc, 'h2', 'event-group__heading', group.label);
+            // Ties the group's cards to their month for assistive tech.
+            section.setAttribute('aria-labelledby', `month-${group.key}`);
+            heading.id = `month-${group.key}`;
+            section.appendChild(heading);
+        }
+
+        for (const entry of group.items) {
+            const card = buildCard(entry);
+            if (card) section.appendChild(card);
+        }
+        return section;
+    }
+
+    /**
+     * Replaces the contents of `container` with the grouped results, or the
+     * empty state when there are none.
+     */
+    function renderResults(container, entries, options = {}) {
+        if (!container) return;
+        const doc = options.doc || container.ownerDocument;
+        const buildCard =
+            options.buildCard ||
+            ((entry) => global.NycCards && global.NycCards.buildEventCard(entry, { type: 'popup' }));
+
+        container.replaceChildren();
+
+        const list = Array.isArray(entries) ? entries : [];
+        if (list.length === 0) {
+            container.appendChild(buildEmptyState(doc, options));
+            return;
+        }
+
+        for (const group of groupByMonth(list)) {
+            container.appendChild(buildGroup(doc, group, buildCard));
+        }
+    }
+
+    const api = {
+        EMPTY_MESSAGE,
+        EMPTY_ACTION_LABEL,
+        getMonthKey,
+        formatMonthHeading,
+        groupByMonth,
+        buildEmptyState,
+        renderResults,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (global) global.NycPopupsList = api;
+})(typeof window !== 'undefined' ? window : null);

--- a/tests/e2e/redesign-popups-filtering.spec.js
+++ b/tests/e2e/redesign-popups-filtering.spec.js
@@ -74,14 +74,19 @@ test.beforeEach(async ({ page }) => {
   )
 })
 
-/** Names currently rendered in the results grid, in order. */
+/** Names currently rendered in the results grid, in order.
+ *  #296 replaced the legacy tiles with grouped event cards. */
 async function renderedNames(page) {
-  return page.locator('#popupsGrid .popup-tile__details h3').allTextContents()
+  return page.locator('#popupsGrid .event-card__title').allTextContents()
 }
+
+/** Results are nested inside month groups, so count cards rather than children. */
+const resultCards = (page) => page.locator('#popupsGrid .event-card')
 
 async function gotoPopups(page, { flag = 'on' } = {}) {
   await page.goto(`/pop-ups.html?redesign=${flag}`)
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(DOCUMENTS.length)
+  const items = flag === 'on' ? resultCards(page) : page.locator('#popupsGrid .popup-tile')
+  await expect(items).toHaveCount(DOCUMENTS.length)
 }
 
 /** Opens a chip's dropdown and picks the option with the given label. */
@@ -94,7 +99,7 @@ test('search narrows the results to matching events', async ({ page }) => {
   await gotoPopups(page)
 
   await page.locator('.search-bar__input').fill('chelsea')
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(1)
+  await expect(resultCards(page)).toHaveCount(1)
   expect(await renderedNames(page)).toEqual(['Chelsea Night Market'])
 
   // Venue and neighborhood are searchable too, not just the name.
@@ -144,7 +149,7 @@ test('a chip reflects its selection and clears from the All option', async ({ pa
   await chooseFilter(page, 'borough', 'All Boroughs')
   await expect(chip.locator('.filter-chip__label')).toHaveText('Borough')
   await expect(chip).not.toHaveClass(/filter-chip--active/)
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+  await expect(resultCards(page)).toHaveCount(4)
 })
 
 test('the neighborhood options come from the loaded data', async ({ page }) => {
@@ -171,7 +176,7 @@ test('the date range filters on overlap and clears again', async ({ page }) => {
   expect(await renderedNames(page)).toEqual(['Chelsea Night Market'])
 
   await page.evaluate(() => window.NycFilters.setFilter('dates', null))
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+  await expect(resultCards(page)).toHaveCount(4)
 })
 
 test('Clear all resets the chips and the search box together', async ({ page }) => {
@@ -179,7 +184,7 @@ test('Clear all resets the chips and the search box together', async ({ page }) 
 
   await page.locator('.search-bar__input').fill('chelsea')
   await chooseFilter(page, 'borough', 'Manhattan')
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(1)
+  await expect(resultCards(page)).toHaveCount(1)
 
   const clear = page.locator('.filter-bar__clear')
   await expect(clear).toBeVisible()
@@ -187,7 +192,7 @@ test('Clear all resets the chips and the search box together', async ({ page }) 
 
   await expect(page.locator('.search-bar__input')).toHaveValue('')
   await expect(page.locator('.filter-chip[data-filter="borough"] .filter-chip__label')).toHaveText('Borough')
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+  await expect(resultCards(page)).toHaveCount(4)
   await expect(clear).toBeHidden()
 })
 
@@ -199,7 +204,7 @@ test('filtering works the same on a phone', async ({ page }) => {
   expect(await renderedNames(page)).toEqual(['Astoria Beer Garden Sessions'])
 
   await page.locator('.filter-bar__clear').click()
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+  await expect(resultCards(page)).toHaveCount(4)
 })
 
 test('the flag-off page renders everything and ignores the controls', async ({ page }) => {
@@ -213,7 +218,9 @@ test('the flag-off page renders everything and ignores the controls', async ({ p
   await page.evaluate(() => {
     document.dispatchEvent(new CustomEvent('search:change', { detail: { query: 'chelsea' } }))
   })
-  await expect(page.locator('#popupsGrid > *')).toHaveCount(4)
+  // Legacy tiles, not cards, and still all four of them.
+  await expect(page.locator('#popupsGrid .popup-tile')).toHaveCount(4)
+  await expect(resultCards(page)).toHaveCount(0)
 })
 
 test('the page loads with no errors once filtering is wired', async ({ page }) => {

--- a/tests/e2e/redesign-popups-list.spec.js
+++ b/tests/e2e/redesign-popups-list.spec.js
@@ -1,0 +1,153 @@
+const { test, expect } = require('@playwright/test')
+
+const IMG = '/resources/images/images/default-popup-image.webp'
+
+const doc = (id, name, start, extra = {}) => ({
+  _id: id,
+  slug: id,
+  name,
+  start_datetime: start,
+  category: 'market',
+  borough: 'manhattan',
+  neighborhood: 'SoHo',
+  venue_name: 'A Venue',
+  price: 'Free',
+  short_description: 'Something worth turning up for.',
+  imageUrl: IMG,
+  display_overall: true,
+  display_in_popups_page: true,
+  ...extra,
+})
+
+// Deliberately out of order, spanning three months, with one featured entry
+// mid-run and one all-day event on a month boundary.
+const DOCUMENTS = [
+  doc('sept-fair', 'September Fair', '2026-09-05T14:00:00Z'),
+  doc('aug-market', 'August Market', '2026-08-13T15:00:00Z'),
+  doc('aug-featured', 'August Featured Show', '2026-08-20T14:00:00Z', { is_featured: true }),
+  doc('oct-late', 'October Late Show', '2026-10-02T14:00:00Z'),
+  doc('aug-allday', 'August All Day', null, { start_date: '2026-08-31', end_date: '2026-08-31', all_day: true }),
+]
+
+test.beforeEach(async ({ page }) => {
+  await page.route('https://41kk82h2.apicdn.sanity.io/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ result: DOCUMENTS }),
+    })
+  )
+})
+
+async function gotoList(page, flag = 'on') {
+  await page.goto(`/pop-ups.html?redesign=${flag}`)
+  if (flag === 'on') await expect(page.locator('.event-card').first()).toBeVisible()
+}
+
+test('results render as event cards rather than legacy tiles', async ({ page }) => {
+  await gotoList(page)
+
+  await expect(page.locator('.event-card')).toHaveCount(5)
+  await expect(page.locator('#popupsGrid .popup-tile')).toHaveCount(0)
+})
+
+test('cards are grouped under month headings in chronological order', async ({ page }) => {
+  await gotoList(page)
+
+  await expect(page.locator('.event-group__heading')).toHaveText([
+    'August 2026',
+    'September 2026',
+    'October 2026',
+  ])
+
+  // Within August, date order — and the featured card is not hoisted.
+  const august = page.locator('.event-group').first()
+  await expect(august.locator('.event-card__title')).toHaveText([
+    'August Market',
+    'August Featured Show',
+    'August All Day',
+  ])
+})
+
+test('an all-day event on a month boundary lands in the right month', async ({ page }) => {
+  await gotoList(page)
+
+  // 2026-08-31 parsed as UTC midnight would be 30 August in New York — still
+  // August — but the same bug files 1 September events under August. Assert the
+  // 31st stays in August rather than slipping to September.
+  const august = page.locator('.event-group').first()
+  await expect(august.locator('.event-card__title')).toContainText(['August All Day'])
+  await expect(august.locator('.event-card__day-number').last()).toHaveText('31')
+})
+
+test('the featured entry uses the featured card treatment', async ({ page }) => {
+  await gotoList(page)
+
+  const featured = page.locator('.event-card--featured')
+  await expect(featured).toHaveCount(1)
+  await expect(featured.locator('.event-card__title')).toHaveText('August Featured Show')
+})
+
+test('the results count reports events, not month groups', async ({ page }) => {
+  await gotoList(page)
+
+  // Five cards across three groups: counting children would say 3.
+  await expect(page.locator('.results-count')).toHaveText('5 events found')
+})
+
+test('the empty state offers a way out and restores the results', async ({ page }) => {
+  await gotoList(page)
+
+  await page.locator('.search-bar__input').fill('nothing matches this')
+
+  const empty = page.locator('.results-empty')
+  await expect(empty).toBeVisible()
+  await expect(empty).toContainText('No pop-ups match these filters')
+  await expect(page.locator('.event-card')).toHaveCount(0)
+  await expect(page.locator('.event-group__heading')).toHaveCount(0)
+  await expect(page.locator('.results-count')).toHaveText('0 events found')
+
+  await empty.getByRole('button', { name: 'Clear all filters' }).click()
+
+  await expect(page.locator('.search-bar__input')).toHaveValue('')
+  await expect(page.locator('.event-card')).toHaveCount(5)
+  await expect(empty).toBeHidden()
+})
+
+test('filtering re-groups the remaining results', async ({ page }) => {
+  await gotoList(page)
+
+  await page.locator('.search-bar__input').fill('september')
+
+  await expect(page.locator('.event-group__heading')).toHaveText(['September 2026'])
+  await expect(page.locator('.event-card')).toHaveCount(1)
+})
+
+test('the month heading is a real heading for screen readers', async ({ page }) => {
+  await gotoList(page)
+
+  const heading = page.getByRole('heading', { level: 2, name: 'August 2026' })
+  await expect(heading).toBeVisible()
+
+  // Each group is labelled by its month, so the cards are announced in context.
+  const labelled = await page.locator('.event-group').first().getAttribute('aria-labelledby')
+  expect(labelled).toBe(await heading.getAttribute('id'))
+})
+
+test('groups and the empty state stay invisible with the flag off', async ({ page }) => {
+  await gotoList(page, 'off')
+
+  await expect(page.locator('#popupsGrid .popup-tile')).toHaveCount(5)
+  await expect(page.locator('.event-card')).toHaveCount(0)
+  await expect(page.locator('.event-group__heading')).toHaveCount(0)
+  await expect(page.locator('.results-empty')).toHaveCount(0)
+})
+
+test('the list page loads with no errors', async ({ page }) => {
+  const errors = []
+  page.on('pageerror', (error) => errors.push(error.message))
+
+  await gotoList(page)
+
+  expect(errors).toEqual([])
+})

--- a/tests/unit/popups-list.spec.js
+++ b/tests/unit/popups-list.spec.js
@@ -1,0 +1,91 @@
+const { groupByMonth, getMonthKey, formatMonthHeading } = require('../../resources/js/popups-list.js')
+
+const popup = (id, start, extra = {}) => ({ id, name: id, start_datetime: start, ...extra })
+
+describe('getMonthKey', () => {
+  it('keys an entry by the month its start date falls in', () => {
+    expect(getMonthKey(popup('a', '2026-08-13T15:00:00.000Z'))).toBe('2026-08')
+  })
+
+  it('anchors date-only values at noon UTC so the month never slips', () => {
+    // new Date('2026-09-01') is UTC midnight, i.e. 31 August in New York, which
+    // would file an all-day event under the wrong month heading.
+    expect(getMonthKey(popup('a', '2026-09-01'))).toBe('2026-09')
+    expect(getMonthKey(popup('b', '2026-08-31'))).toBe('2026-08')
+  })
+
+  it('keeps a late-evening event in its own Eastern month', () => {
+    // 1 Sep 01:00 UTC is 31 Aug 21:00 in New York.
+    expect(getMonthKey(popup('a', '2026-09-01T01:00:00.000Z'))).toBe('2026-08')
+  })
+
+  it('returns null for an entry with no usable date', () => {
+    expect(getMonthKey(popup('a', ''))).toBeNull()
+    expect(getMonthKey(popup('a', 'not-a-date'))).toBeNull()
+  })
+})
+
+describe('formatMonthHeading', () => {
+  it('reads as month and year', () => {
+    expect(formatMonthHeading('2026-08')).toBe('August 2026')
+    expect(formatMonthHeading('2027-01')).toBe('January 2027')
+  })
+})
+
+describe('groupByMonth', () => {
+  it('returns one group per month, in chronological order', () => {
+    const groups = groupByMonth([
+      popup('sept', '2026-09-05T14:00:00.000Z'),
+      popup('aug-early', '2026-08-13T15:00:00.000Z'),
+      popup('aug-late', '2026-08-22T14:00:00.000Z'),
+    ])
+
+    expect(groups.map((group) => group.key)).toEqual(['2026-08', '2026-09'])
+    expect(groups[0].label).toBe('August 2026')
+    expect(groups[0].items.map((item) => item.id)).toEqual(['aug-early', 'aug-late'])
+    expect(groups[1].items.map((item) => item.id)).toEqual(['sept'])
+  })
+
+  it('orders entries within a month by start date', () => {
+    const groups = groupByMonth([
+      popup('later', '2026-08-22T14:00:00.000Z'),
+      popup('earlier', '2026-08-03T14:00:00.000Z'),
+    ])
+    expect(groups[0].items.map((item) => item.id)).toEqual(['earlier', 'later'])
+  })
+
+  it('files a multi-month run under the month it starts in', () => {
+    const groups = groupByMonth([
+      popup('run', '2026-08-28T14:00:00.000Z', { end_datetime: '2026-10-02T14:00:00.000Z' }),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].key).toBe('2026-08')
+  })
+
+  it('keeps featured entries in date order rather than hoisting them', () => {
+    const groups = groupByMonth([
+      popup('plain', '2026-08-03T14:00:00.000Z'),
+      popup('featured', '2026-08-20T14:00:00.000Z', { is_featured: true }),
+    ])
+    expect(groups[0].items.map((item) => item.id)).toEqual(['plain', 'featured'])
+  })
+
+  it('collects undated entries into a trailing group with no heading', () => {
+    const groups = groupByMonth([popup('undated', ''), popup('dated', '2026-08-03T14:00:00.000Z')])
+
+    expect(groups.map((group) => group.key)).toEqual(['2026-08', null])
+    expect(groups[1].label).toBe('')
+    expect(groups[1].items.map((item) => item.id)).toEqual(['undated'])
+  })
+
+  it('returns nothing for an empty list', () => {
+    expect(groupByMonth([])).toEqual([])
+    expect(groupByMonth(undefined)).toEqual([])
+  })
+
+  it('does not mutate the list it is given', () => {
+    const list = [popup('b', '2026-09-05T14:00:00.000Z'), popup('a', '2026-08-13T15:00:00.000Z')]
+    groupByMonth(list)
+    expect(list.map((item) => item.id)).toEqual(['b', 'a'])
+  })
+})


### PR DESCRIPTION
Closes #296.

Swaps the legacy `.popup-tile` loop for the shared card system when the flag is on, grouped by month.

## What changed

**New `resources/js/popups-list.js`** (`window.NycPopupsList`) owns result presentation — month grouping, the cards, the no-results state. `pop-ups.js` keeps only fetching and filtering, which leaves #297 a clean seam for the modal flow.

**Grouping** follows §6.4: a Playfair month heading over a 1px rule per group, chronological, entries in date order within a month. Three readings the spec left open, recorded so they're not re-litigated:

- A **multi-month run appears once**, under the month it starts in.
- **Featured entries stay in date order** rather than being hoisted to the top — that's how the featured card reads in image7, sitting in the run.
- **Undated entries** collect into a trailing group with no heading, rather than being dropped.

Month keys are derived in Eastern time from a noon-UTC anchor, so an all-day event on the 1st doesn't file under the previous month. There's a test pinning that specifically.

**The no-results state is derived** — REDESIGN.md doesn't specify one and the site has never had one. Per your call it carries a message plus a *Clear all filters* button; with four filters plus search it's an easy dead end to reach, and the reset was already wired through `filters:clear` in #295. Loading state deliberately unchanged: the prebuild already puts static tiles in the markup, so there's no empty gap on a real page load.

## A counting bug this fixes

I flagged on #295 that `filters.js` counted `#popupsGrid.childElementCount`. With grouping that would have reported **3 groups instead of 5 events**, and counted the empty-state panel as one result. It now counts result items and observes the subtree, since cards nest inside groups. There's a test asserting "5 events found" across 3 groups.

## Tests

Unit tests written first and watched fail. The e2e tests came after the wiring, so I mutation-checked them: flattening the grouping and hoisting featured entries each fail exactly the tests covering them, independently.

- `tests/unit/popups-list.spec.js` (12) — month keys including the timezone boundary, heading format, ordering, multi-month runs, featured placement, undated entries, immutability.
- `tests/e2e/redesign-popups-list.spec.js` (10) — cards not tiles, grouped headings in order, the all-day month boundary, featured treatment, the count, the empty state round trip, re-grouping on filter, the heading's `aria-labelledby` wiring, and the flag-off page still rendering legacy tiles.

**Modified `redesign-popups-filtering.spec.js`** — its helpers looked for `.popup-tile` and counted `#popusGrid > *`, both of which this issue intentionally changes. They now target `.event-card` and count cards rather than children. The behaviour asserted is unchanged; only the markup underneath moved. Worth a look in review, since changing tests alongside code is how a regression hides.

Full suite: 315 unit, 157 e2e, Stylelint and HTMLHint green.

## Not in this PR

Cards still navigate to `pop-up.html` via their href — the detail modal is #297. The map panel is still empty (#299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
