### PR TITLE
Open the detail modal from Pop-Ups result cards (#297)

### DIFF
--- a/pop-ups.html
+++ b/pop-ups.html
@@ -39,6 +39,7 @@
         <script src="resources/js/cards.js" defer></script>
         <script src="resources/js/popups-list.js" defer></script>
         <script src="resources/js/modal.js" defer></script>
+        <script src="resources/js/popups-modal.js" defer></script>
         <link rel="icon" href="resources/images/icons/favicon.ico" type="image/x-icon">
         <!-- STATIC_JSONLD_START -->
         <!-- STATIC_JSONLD_END -->

--- a/resources/js/modal.js
+++ b/resources/js/modal.js
@@ -266,11 +266,20 @@
 
         overlay.appendChild(card);
 
+        let closed = false;
+
         function close() {
+            // Escape, the return bar and the overlay all land here, as does a
+            // caller closing it directly, so this is the one place that can
+            // tell a caller the modal is gone. Guarded because the callback
+            // may well close it again (see the history handling in #297).
+            if (closed) return;
+            closed = true;
             doc.removeEventListener('keydown', onKeydown, true);
             overlay.remove();
             doc.body.style.overflow = previousOverflow;
             if (opener && typeof opener.focus === 'function') opener.focus();
+            if (typeof settings.onClose === 'function') settings.onClose();
         }
 
         function onKeydown(event) {

--- a/resources/js/pop-ups.js
+++ b/resources/js/pop-ups.js
@@ -671,6 +671,15 @@ function loadAndDisplayPopups() {
                 });
             }
 
+            // Cards open the detail modal rather than navigating. Delegated,
+            // so re-rendering on every filter change needs no re-binding.
+            if (useCards && window.NycPopupsDetail) {
+                window.NycPopupsDetail.initDetailModal(document, grid, {
+                    getEntries: () => popups,
+                    type: 'popup',
+                });
+            }
+
             if (redesignOn && window.NycPopupsFilter) {
                 const controller = window.NycPopupsFilter.createFilterController(document, {
                     onChange: state => renderPopups(window.NycPopupsFilter.filterPopups(popups, state)),

--- a/resources/js/popups-modal.js
+++ b/resources/js/popups-modal.js
@@ -1,0 +1,137 @@
+// Opens the shared detail modal from a Pop-Ups result card, and keeps the
+// browser history in step so Back dismisses the modal rather than leaving the
+// list. The modal itself (focus trap, dismissal, scroll lock) is modal.js;
+// this is only the glue between a card and that component.
+// See REDESIGN.md section 6.5.
+//
+// Wrapped in an IIFE: classic scripts share one global lexical scope, and a
+// duplicate top-level declaration silently kills a whole file.
+(function (global) {
+    'use strict';
+
+    // === CONSTANTS ===
+
+    const CARD_SELECTOR = '.event-card';
+
+    const RETURN_LABEL = 'Return to all pop-ups';
+
+    /** Marks the history entry this module pushed, so popstate can tell. */
+    const HISTORY_FLAG = 'nycDetailModal';
+
+    // === PURE HELPERS ===
+
+    /** Reads the entry id out of a card's href, e.g. 'pop-up.html?id=flavia'. */
+    function getEntryId(href) {
+        if (!href) return null;
+        const query = String(href).split('?')[1];
+        if (!query) return null;
+        const match = /(?:^|&)id=([^&]*)/.exec(query);
+        return match ? decodeURIComponent(match[1]) : null;
+    }
+
+    function findEntry(entries, id) {
+        if (!id || !Array.isArray(entries)) return null;
+        return entries.find(entry => String(entry.id) === String(id)) || null;
+    }
+
+    /**
+     * A modified click means the person asked the browser for something else —
+     * a new tab, a new window, a download — so the card has to stay a plain
+     * link for those. Only a plain left click becomes a modal.
+     */
+    function isPlainLeftClick(event) {
+        return (
+            event.button === 0 &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.shiftKey &&
+            !event.altKey &&
+            !event.defaultPrevented
+        );
+    }
+
+    // === DOM WIRING ===
+
+    /**
+     * Delegates clicks within `container`. `getEntries` supplies the current
+     * list, so filtering and re-rendering need no re-binding.
+     */
+    function initDetailModal(doc, container, { getEntries, type = 'popup' } = {}) {
+        if (!doc || !container) return null;
+
+        let open = null;
+        // True while the history entry this module pushed is still current.
+        let pushed = false;
+        const view = doc.defaultView || global;
+
+        function closeOpen() {
+            if (!open) return;
+            const handle = open;
+            open = null;
+            handle.close();
+        }
+
+        function onModalClosed() {
+            open = null;
+            // Dismissed from inside the modal, so drop the entry we pushed.
+            // Skipped when popstate already removed it.
+            if (pushed) {
+                pushed = false;
+                view.history.back();
+            }
+        }
+
+        function openFor(entry, href) {
+            if (!global.NycModal) return;
+
+            // The pushed URL is the entry's own detail page, so a copied or
+            // reloaded link still resolves to real content.
+            view.history.pushState({ [HISTORY_FLAG]: entry.id }, '', href);
+            pushed = true;
+
+            open = global.NycModal.openDetailModal(entry, {
+                document: doc,
+                type,
+                returnLabel: RETURN_LABEL,
+                onClose: onModalClosed,
+            });
+        }
+
+        container.addEventListener('click', event => {
+            const card = event.target.closest(CARD_SELECTOR);
+            if (!card || !container.contains(card)) return;
+            if (!isPlainLeftClick(event)) return;
+
+            const entry = findEntry(
+                typeof getEntries === 'function' ? getEntries() : [],
+                getEntryId(card.getAttribute('href'))
+            );
+            if (!entry) return;
+
+            event.preventDefault();
+            openFor(entry, card.getAttribute('href'));
+        });
+
+        view.addEventListener('popstate', () => {
+            // The entry is already gone, so closing must not call back().
+            pushed = false;
+            closeOpen();
+        });
+
+        return { close: closeOpen, isOpen: () => open !== null };
+    }
+
+    // === BOOTSTRAP ===
+
+    const api = {
+        CARD_SELECTOR,
+        RETURN_LABEL,
+        getEntryId,
+        findEntry,
+        isPlainLeftClick,
+        initDetailModal,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (global) global.NycPopupsDetail = api;
+})(typeof window !== 'undefined' ? window : null);

--- a/tests/e2e/redesign-popups-detail.spec.js
+++ b/tests/e2e/redesign-popups-detail.spec.js
@@ -1,0 +1,198 @@
+const { test, expect } = require('@playwright/test')
+
+const DOCUMENTS = [
+  {
+    _id: 'flavia',
+    slug: 'flavia',
+    name: 'Flavia Flavor Lounge',
+    start_datetime: '2026-08-13T15:00:00Z',
+    end_datetime: '2026-08-14T23:00:00Z',
+    category: 'food_drink',
+    borough: 'manhattan',
+    neighborhood: 'SoHo',
+    venue_name: '22 Wooster',
+    address: '22 Wooster St, New York, NY 10013',
+    price: 'Free',
+    short_description: 'Sip complimentary coffee and tea.',
+    long_description: 'A loft space built for lingering, with a rotating cast of roasters.',
+    imageUrl: '/resources/images/images/default-popup-image.webp',
+    display_overall: true,
+    display_in_popups_page: true,
+  },
+  {
+    _id: 'chelsea',
+    slug: 'chelsea',
+    name: 'Chelsea Night Market',
+    start_datetime: '2026-08-15T22:00:00Z',
+    category: 'market',
+    borough: 'manhattan',
+    neighborhood: 'Chelsea',
+    venue_name: 'Chelsea Piers',
+    price: '$15',
+    short_description: 'Forty vendors after dark.',
+    imageUrl: '/resources/images/images/default-popup-image.webp',
+    display_overall: true,
+    display_in_popups_page: true,
+  },
+]
+
+test.beforeEach(async ({ page }) => {
+  await page.route('https://41kk82h2.apicdn.sanity.io/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ result: DOCUMENTS }),
+    })
+  )
+})
+
+async function gotoList(page, flag = 'on') {
+  await page.goto(`/pop-ups.html?redesign=${flag}`)
+  const item = flag === 'on' ? page.locator('.event-card') : page.locator('#popupsGrid .popup-tile')
+  await expect(item.first()).toBeVisible()
+}
+
+const modal = (page) => page.locator('.modal--detail')
+const firstCard = (page) => page.locator('.event-card').first()
+
+test('clicking a card opens the detail modal instead of navigating', async ({ page }) => {
+  await gotoList(page)
+  await firstCard(page).click()
+
+  await expect(modal(page)).toBeVisible()
+  expect(new URL(page.url()).pathname).toBe('/pop-up.html')
+  // Still the list page underneath — no document navigation happened.
+  await expect(page.locator('#popupsGrid')).toBeAttached()
+})
+
+test('the modal shows the event detail content', async ({ page }) => {
+  await gotoList(page)
+  await firstCard(page).click()
+
+  const card = modal(page)
+  await expect(card.getByRole('heading', { name: 'Flavia Flavor Lounge' })).toBeVisible()
+  await expect(card).toContainText('22 Wooster')
+  await expect(card).toContainText('A loft space built for lingering')
+  await expect(card).toContainText('Free')
+  await expect(card.getByRole('link', { name: /google calendar/i })).toBeVisible()
+  await expect(card.getByRole('button', { name: /share event/i })).toBeVisible()
+  await expect(card.locator('.modal-detail__image')).toBeVisible()
+})
+
+test('the return bar names where you are going back to', async ({ page }) => {
+  await gotoList(page)
+  await firstCard(page).click()
+
+  await expect(modal(page).locator('.modal-return-bar')).toHaveText('← Return to all pop-ups')
+})
+
+for (const [label, dismiss] of [
+  ['the return bar', async (page) => page.locator('.modal-return-bar').click()],
+  ['Escape', async (page) => page.keyboard.press('Escape')],
+  ['clicking the overlay', async (page) => page.locator('.modal--detail').click({ position: { x: 5, y: 5 } })],
+]) {
+  test(`${label} closes the modal and restores the list URL`, async ({ page }) => {
+    await gotoList(page)
+    await firstCard(page).click()
+    await expect(modal(page)).toBeVisible()
+
+    await dismiss(page)
+
+    await expect(modal(page)).toHaveCount(0)
+    // The history entry pushed on open must not be left behind.
+    expect(new URL(page.url()).pathname).toBe('/pop-ups.html')
+  })
+}
+
+test('the browser Back button closes the modal and keeps you on the list', async ({ page }) => {
+  await gotoList(page)
+  await firstCard(page).click()
+  await expect(modal(page)).toBeVisible()
+
+  await page.goBack()
+
+  await expect(modal(page)).toHaveCount(0)
+  expect(new URL(page.url()).pathname).toBe('/pop-ups.html')
+  await expect(page.locator('.event-card')).toHaveCount(2)
+})
+
+test('opening a second card after closing the first still works', async ({ page }) => {
+  await gotoList(page)
+
+  await firstCard(page).click()
+  await page.keyboard.press('Escape')
+  await expect(modal(page)).toHaveCount(0)
+
+  await page.locator('.event-card').nth(1).click()
+  await expect(modal(page).getByRole('heading', { name: 'Chelsea Night Market' })).toBeVisible()
+})
+
+test('focus moves into the modal and returns to the card afterwards', async ({ page }) => {
+  await gotoList(page)
+  await firstCard(page).focus()
+  await firstCard(page).click()
+
+  const insideModal = await page.evaluate(
+    () => document.activeElement.closest('.modal--detail') !== null
+  )
+  expect(insideModal).toBe(true)
+
+  await page.keyboard.press('Escape')
+  await expect(firstCard(page)).toBeFocused()
+})
+
+test('the card stays a real link so it can be opened in a new tab', async ({ page }) => {
+  await gotoList(page)
+
+  // Intercepting a plain click must not cost middle-click, cmd-click or no-JS.
+  await expect(firstCard(page)).toHaveAttribute('href', 'pop-up.html?id=flavia')
+
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+  const [opened] = await Promise.all([
+    page.context().waitForEvent('page'),
+    firstCard(page).click({ modifiers: [modifier] }),
+  ])
+  await opened.waitForURL(/pop-up\.html/)
+
+  expect(new URL(opened.url()).pathname).toBe('/pop-up.html')
+  // The list page did not open a modal for the modified click.
+  await expect(modal(page)).toHaveCount(0)
+  await opened.close()
+})
+
+test('the modal works on a phone', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await gotoList(page)
+  await firstCard(page).click()
+
+  await expect(modal(page)).toBeVisible()
+  const overflows = await page.evaluate(() => {
+    const card = document.querySelector('.modal-detail__card')
+    return card.getBoundingClientRect().width > window.innerWidth
+  })
+  expect(overflows).toBe(false)
+
+  await page.locator('.modal-return-bar').click()
+  await expect(modal(page)).toHaveCount(0)
+})
+
+test('the flag-off page still navigates to the detail page', async ({ page }) => {
+  await gotoList(page, 'off')
+
+  await page.locator('#popupsGrid .popup-tile').first().click()
+  await page.waitForURL(/pop-up\.html/)
+
+  expect(new URL(page.url()).pathname).toBe('/pop-up.html')
+  await expect(page.locator('.modal--detail')).toHaveCount(0)
+})
+
+test('the detail flow loads with no page errors', async ({ page }) => {
+  const errors = []
+  page.on('pageerror', (error) => errors.push(error.message))
+
+  await gotoList(page)
+  await firstCard(page).click()
+  await page.keyboard.press('Escape')
+
+  expect(errors).toEqual([])
+})

--- a/tests/unit/popups-modal.spec.js
+++ b/tests/unit/popups-modal.spec.js
@@ -1,0 +1,78 @@
+const { getEntryId, findEntry, isPlainLeftClick, RETURN_LABEL } = require('../../resources/js/popups-modal.js')
+
+describe('getEntryId', () => {
+  it('reads the id a card links to', () => {
+    expect(getEntryId('pop-up.html?id=flavia')).toBe('flavia')
+  })
+
+  it('decodes an escaped id', () => {
+    expect(getEntryId('pop-up.html?id=flavia%20lounge')).toBe('flavia lounge')
+  })
+
+  it('finds the id among other parameters', () => {
+    expect(getEntryId('pop-up.html?redesign=on&id=flavia')).toBe('flavia')
+    expect(getEntryId('pop-up.html?id=flavia&redesign=on')).toBe('flavia')
+  })
+
+  it('does not match a parameter that merely ends in id', () => {
+    expect(getEntryId('pop-up.html?venueid=flavia')).toBeNull()
+  })
+
+  it('returns null when there is nothing to read', () => {
+    expect(getEntryId('pop-up.html')).toBeNull()
+    expect(getEntryId('')).toBeNull()
+    expect(getEntryId(null)).toBeNull()
+  })
+})
+
+describe('findEntry', () => {
+  const entries = [{ id: 'flavia' }, { id: 'chelsea' }]
+
+  it('finds the matching entry', () => {
+    expect(findEntry(entries, 'chelsea')).toBe(entries[1])
+  })
+
+  it('returns null for an unknown or missing id', () => {
+    expect(findEntry(entries, 'nope')).toBeNull()
+    expect(findEntry(entries, null)).toBeNull()
+    expect(findEntry(undefined, 'flavia')).toBeNull()
+  })
+})
+
+describe('isPlainLeftClick', () => {
+  const click = (overrides = {}) => ({
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    ...overrides,
+  })
+
+  it('accepts an ordinary left click', () => {
+    expect(isPlainLeftClick(click())).toBe(true)
+  })
+
+  it.each([
+    ['middle click', { button: 1 }],
+    ['cmd-click', { metaKey: true }],
+    ['ctrl-click', { ctrlKey: true }],
+    ['shift-click', { shiftKey: true }],
+    ['alt-click', { altKey: true }],
+  ])('leaves %s to the browser', (_label, overrides) => {
+    // These all mean "open this link some other way", which is why the card
+    // stays a real anchor rather than becoming a button.
+    expect(isPlainLeftClick(click(overrides))).toBe(false)
+  })
+
+  it('ignores a click something else already handled', () => {
+    expect(isPlainLeftClick(click({ defaultPrevented: true }))).toBe(false)
+  })
+})
+
+describe('return label', () => {
+  it('names the page being returned to, per section 6.5', () => {
+    expect(RETURN_LABEL).toBe('Return to all pop-ups')
+  })
+})


### PR DESCRIPTION
Closes #297.

Cards now open the shared detail modal instead of navigating to `pop-up.html`. The modal component already owned focus trapping, dismissal and the scroll lock, so this is glue.

## What changed

**New `resources/js/popups-modal.js`** (`window.NycPopupsDetail`) — a delegated click handler on the results grid, so re-rendering on every filter change needs no re-binding, plus the history handling below.

**Cards stay real anchors.** Only a plain left click becomes a modal; cmd-click, ctrl-click, middle-click, shift and alt are left to the browser, and the `href` still works with JS off. There's a test that cmd-click really does open `pop-up.html` in a new tab and does *not* also open a modal — easy thing to break by reaching for a `<button>`.

**Back closes the modal**, per your call. Opening pushes the entry's own detail URL, so:

- a copied or reloaded link resolves to real content on the standalone page
- Back dismisses the modal in place rather than leaving the list and losing scroll position and active filters

Dismissing from inside (Escape, return bar, overlay) pops that entry so nothing stale is left in history; the `popstate` path clears the flag first so the two can't fight and send you back twice. Both directions are covered by tests, and I mutation-checked each guard independently — removing either fails exactly the tests that cover it.

**`modal.js` gains an `onClose` option.** Without it a caller can't notice a dismissal it didn't initiate, which is what leaves a stale history entry. `close()` is now guarded against re-entry, since the callback may well close it again. Small addition to a shared component; date ideas will want it too.

## Tests

e2e written first: 12 of 13 failed.

- `tests/e2e/redesign-popups-detail.spec.js` (13) — opening without navigating, the §6.5 content, the return label, all three dismissal routes each restoring the URL, Back, opening a second card after the first, focus moving in and returning to the card, cmd-click, a phone viewport, and the flag-off page still navigating.
- `tests/unit/popups-modal.spec.js` (15) — id parsing including the `venueid` near-miss, entry lookup, and every modified-click variant.

Full suite: 330 unit, 170 e2e, Stylelint and HTMLHint green.

## One thing I found and did not fix here

**[#380](https://github.com/anewbegin95/project-pizza/issues/380) — the modal has the same height bug as #376.** `.modal-detail__image` uses `height: 100%` inside a grid area with no definite height, so the source image sets the modal's height: at 1440px the same event renders **699px tall with a portrait image and 509px with a landscape one**. Mobile is fine — it already has `aspect-ratio: 16 / 9`, which is the fix desktop is missing.

It was invisible until this PR, since nothing opened the modal before. I've filed it rather than folding it in, to keep this PR to the wiring and because `modals.css` is shared with date ideas — same reasoning as splitting #376 out of #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
