### PR TITLE
Stop the source image dictating detail modal height (#380)

### DIFF
--- a/resources/css/modals.css
+++ b/resources/css/modals.css
@@ -109,6 +109,9 @@ body.redesign-enabled .modal--detail[hidden] {
 body.redesign-enabled .modal-detail__card {
   display: grid;
   grid-template-columns: 45% 55%;
+  /* minmax(0, 1fr) rather than a bare 1fr: the content row has to be allowed
+     to shrink, or the body cannot scroll inside it. */
+  grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
     'bar bar'
     'body media';
@@ -153,8 +156,13 @@ body.redesign-enabled .modal-detail__body {
   flex-direction: column;
   gap: var(--space-sm);
   overflow-y: auto;
+  /* Grid items default to min-height:auto, which stops them shrinking below
+     their content — so overflow-y never engaged and a long description was
+     silently clipped by the card's max-height instead of scrolling. */
+  min-height: 0;
   padding: var(--space-sm-md);
 }
+
 
 :root[data-redesign='on'] .modal-detail__tags,
 body.redesign-enabled .modal-detail__tags {
@@ -228,12 +236,21 @@ body.redesign-enabled .modal-detail__share:hover {
 
 :root[data-redesign='on'] .modal-detail__media,
 body.redesign-enabled .modal-detail__media {
+  position: relative;
   grid-area: media;
   overflow: hidden;
 }
 
+/* Absolutely positioned so the photo contributes nothing to layout height.
+   `height: 100%` in a grid area with no definite height falls back to the
+   image's intrinsic height, which made the modal as tall as whatever was
+   uploaded — 699px for a 563x750 portrait against 509px for a landscape. The
+   row is sized by the body column instead, which is what section 6.5's
+   "full-height photo, object-fit: cover" describes. Same fix as #376. */
 :root[data-redesign='on'] .modal-detail__image,
 body.redesign-enabled .modal-detail__image {
+  position: absolute;
+  inset: 0;
   display: block;
   width: 100%;
   height: 100%;

--- a/tests/e2e/redesign-modal-height.spec.js
+++ b/tests/e2e/redesign-modal-height.spec.js
@@ -1,0 +1,114 @@
+const { test, expect } = require('@playwright/test')
+
+// Real files from the repo, chosen for their aspect ratios.
+const IMAGES = {
+  portrait: '/resources/images/images/default-popup-image.webp', // 563x750
+  landscape: '/resources/images/banners/midtown_manhattan_skyline.webp', // 1920x1280
+  square: '/resources/images/images/profile.webp', // 256x256
+}
+
+const EVENT = {
+  id: 'flavia',
+  name: 'Flavia Flavor Lounge',
+  start_datetime: '2026-08-13T15:00:00.000Z',
+  end_datetime: '2026-08-14T23:00:00.000Z',
+  category: 'food_drink',
+  venue_name: '22 Wooster',
+  address: '22 Wooster St, New York, NY 10013',
+  price: 'Free',
+  long_desc: 'A loft space built for lingering, with a rotating cast of roasters pouring all afternoon.',
+}
+
+/** Opens the modal directly, waits for the image, and measures. */
+async function measureModal(page, { img, data = EVENT }) {
+  return page.evaluate(
+    async ({ data, img }) => {
+      document.querySelector('.modal--detail')?.remove()
+      const handle = window.NycModal.openDetailModal(
+        { ...data, img },
+        { type: 'popup', returnLabel: 'Return to all pop-ups' }
+      )
+      const image = document.querySelector('.modal-detail__image')
+      if (!image.complete) await new Promise((r) => { image.onload = r; image.onerror = r })
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+
+      const card = document.querySelector('.modal-detail__card').getBoundingClientRect()
+      const media = document.querySelector('.modal-detail__media').getBoundingClientRect()
+      const rendered = image.getBoundingClientRect()
+      const body = document.querySelector('.modal-detail__body')
+      const result = {
+        card: Math.round(card.height),
+        media: Math.round(media.height),
+        image: Math.round(rendered.height),
+        bodyScrolls: body.scrollHeight > body.clientHeight + 1,
+        objectFit: getComputedStyle(image).objectFit,
+        viewport: window.innerHeight,
+      }
+      handle.close()
+      return result
+    },
+    { data, img }
+  )
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/pop-ups.html?redesign=on')
+})
+
+for (const [label, width] of [['desktop', 1440], ['laptop', 1024]]) {
+  test(`modal height ignores the source image's aspect ratio on ${label}`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 1000 })
+
+    const heights = {}
+    for (const [name, img] of Object.entries(IMAGES)) {
+      heights[name] = (await measureModal(page, { img })).card
+    }
+
+    expect(new Set(Object.values(heights)).size, `heights were ${JSON.stringify(heights)}`).toBe(1)
+  })
+}
+
+test('the phone layout keeps its 16:9 media and stays image-independent', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+
+  const heights = {}
+  for (const [name, img] of Object.entries(IMAGES)) {
+    heights[name] = (await measureModal(page, { img })).card
+  }
+
+  expect(new Set(Object.values(heights)).size, `heights were ${JSON.stringify(heights)}`).toBe(1)
+})
+
+for (const [name, img] of Object.entries(IMAGES)) {
+  test(`the ${name} photo fills the panel without letterboxing`, async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    const measured = await measureModal(page, { img })
+
+    expect(measured.objectFit).toBe('cover')
+    expect(Math.abs(measured.image - measured.media)).toBeLessThanOrEqual(1)
+  })
+}
+
+test('a sparse entry still gets a usable photo panel', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+
+  const measured = await measureModal(page, {
+    img: IMAGES.landscape,
+    data: { id: 'x', name: 'Short One', start_datetime: '2026-08-13T15:00:00.000Z', price: 'Free' },
+  })
+
+  expect(measured.media).toBeGreaterThanOrEqual(240)
+})
+
+test('a long description scrolls the body rather than growing the modal', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 800 })
+
+  const measured = await measureModal(page, {
+    img: IMAGES.portrait,
+    data: { ...EVENT, long_desc: 'A loft space built for lingering. '.repeat(120) },
+  })
+
+  // max-height is 90vh; the body is the scrolling region.
+  expect(measured.card).toBeLessThanOrEqual(Math.round(measured.viewport * 0.9) + 1)
+  expect(measured.bodyScrolls).toBe(true)
+})


### PR DESCRIPTION
Closes #380.

Same defect as #376, in the modal. `.modal-detail__image` set `width: 100%; height: 100%`, but `.modal-detail__media` is a grid area with no definite height, so `height: 100%` fell back to the image's intrinsic height and the upload set the modal's height.

| Source image | Before | After |
|---|---|---|
| portrait 563×750 | 699px | **509px** |
| landscape 1920×1280 | 509px | **509px** |
| square 256×256 | 535px | **509px** |

The image is now absolutely positioned inside the media panel, so the row is sized by the body column — which is what §6.5's "full-height photo, `object-fit: cover`" describes. Mobile already had `aspect-ratio: 16 / 9` and is unchanged; that was the fix desktop was missing.

## A second bug the test turned up

`.modal-detail__body` sets `overflow-y: auto`, but a grid item's default `min-height: auto` stops it shrinking below its content — so **the overflow never engaged**. A long description was silently clipped by the card's `max-height: 90vh` instead of scrolling: the text was simply unreachable, with no scrollbar to suggest otherwise.

`min-height: 0` on the body plus `minmax(0, 1fr)` on the content row fixes it. This matters more after the first change, since the body is now the only thing sizing the row.

I only found it because the "long description" case was in the test file before the fix was written. It is a pre-existing bug, not one introduced here.

## Tests

Written first: 3 of 8 failed, including the clipping one.

`tests/e2e/redesign-modal-height.spec.js` (8) — height identical across three real images at 1440 and 1024, the phone layout staying image-independent, the photo covering its panel without letterboxing for each image, a sparse entry still getting a usable photo panel, and a long description scrolling the body rather than growing or clipping the modal.

Both fixes mutation-checked separately: putting the image back in flow fails the two height tests, and removing `minmax(0, 1fr)` fails the scrolling test — neither masks the other.

Full suite: 330 unit, 178 e2e, Stylelint and HTMLHint green.

## Note

`modals.css` is shared, so date ideas get both fixes when their detail flow lands in Epic 6.

With this in, **#299 (map view) is the last of Epic 4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
