### PR TITLE
Bring the redesign docs up to date with Epic 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,26 @@ Environment-aware feature flag gating an in-progress redesign, loaded first (blo
 
 ### Redesign shared components (`docs/redesign-components.md`)
 
-Epic 3 built the redesign's shared UI — collage hero, search bar + List/Map toggle, filter bar/chips/dropdowns, date range picker, event cards, detail modal, interior-page shell. **`docs/redesign-components.md` is the reference**: component inventory, public APIs, the events they publish, deviations from REDESIGN.md, and the traps below. Read it before building on them (Epic 4 onwards).
+Epic 3 built the redesign's shared UI — collage hero, search bar + List/Map toggle, filter bar/chips/dropdowns, date range picker, event cards, detail modal, interior-page shell. Epic 4 wired all of it up on Pop-Ups. **`docs/redesign-components.md` is the reference**: component inventory, public APIs, the events they publish, deviations from REDESIGN.md, and the traps below. Read it before building on them.
 
 - **Everything is gated, in both halves.** CSS rules are scoped to `:root[data-redesign='on'], body.redesign-enabled`, and anything that must not appear flag-off carries an unscoped `display: none` default. JS bootstraps return early unless `window.REDESIGN_FLAG.isEnabled()`. A component doing only one half leaks into the legacy experience.
-- **New JS modules are wrapped in an IIFE exposing a single `window.NycX`** (`NycCards`, `NycModal`, `NycFilters`, `NycDatePicker`). Classic scripts share one global lexical scope, so a duplicate top-level `const` silently kills the whole file — this happened with `EASTERN_TIMEZONE` between `cards.js` and `pop-ups.js`. An e2e test asserts each redesign page loads with zero page errors.
-- **Components publish events rather than calling each other**: `viewtoggle:change`, `search:change`, `filters:change`. Nothing consumes them yet; that is Epic 4.
-- **`buttons.css` styles the bare `button` selector** in the legacy pink palette with `padding: 8px 32px`, at a specificity that beats the `.ui-*` primitives — it has caused real bugs in redesign components, which currently restate their own colours to defend against it. Tracked in #372.
-- **Anchor date-only strings at noon UTC.** `new Date('2026-07-25')` is UTC midnight, i.e. the previous evening in Eastern time, so all-day events render a day early. `prebuild-events.js`, `cards.js` and `modal.js` all do this.
+- **New JS modules are wrapped in an IIFE exposing a single `window.NycX`** (`NycCards`, `NycModal`, `NycFilters`, `NycDatePicker`, and the Pop-Ups modules `NycPopupsFilter`, `NycPopupsList`, `NycPopupsDetail`, `NycPopupsMap`). Classic scripts share one global lexical scope, so a duplicate top-level `const` silently kills the whole file — this happened with `EASTERN_TIMEZONE` between `cards.js` and `pop-ups.js`. An e2e test asserts each redesign page loads with zero page errors.
+- **Components publish events rather than calling each other**: `viewtoggle:change`, `search:change`, `filters:change`, `filters:clear`. On Pop-Ups these are consumed by `popups-filter.js` and `popups-map.js`; Date Ideas re-uses them in Epic 6.
+- **Anchor date-only strings at noon UTC.** `new Date('2026-07-25')` is UTC midnight, i.e. the previous evening in Eastern time, so all-day events render a day early. `prebuild-events.js`, `cards.js`, `modal.js`, `popups-filter.js` and `popups-list.js` all do this.
+- **`height: 100%` on an image inside an auto-sized grid area** resolves to the image's intrinsic height, so the source image ends up setting the container's height rather than filling it. Fixed twice — event cards (#376) and the detail modal (#380) — by taking the image out of flow. Related: a grid item with `overflow-y: auto` also needs `min-height: 0`, or the overflow never engages and content is clipped with no scrollbar.
+- **Legacy element and id selectors reach redesign components.** Bare `button` in `buttons.css` did (retired in #372), and `section#popupsGrid` in `popups.css` still sets padding at `!important` that no stack of classes can out-specify. Before retiring one, snapshot computed styles across pages in **both flag states** and diff — #372 found four legacy buttons with no styles of their own, including the menu toggle's 44px touch target.
+
+### Pop-Ups page composition (Epic 4)
+
+`pop-ups.html` is the fully wired reference for the redesign. Its own files, on top of the shared components:
+
+- `resources/css/popups-redesign.css` — results region, single-column card list, month-group headings, no-results state, List/Map panel switching (driven by `data-view` on `<html>`)
+- `resources/js/popups-filter.js` — merges search and filter state into one predicate over the fetched list
+- `resources/js/popups-list.js` — month grouping, card rendering, the empty state
+- `resources/js/popups-modal.js` — card click → detail modal, plus history so Back dismisses it
+- `resources/js/popups-map.js` + `resources/css/map.css` — Leaflet map, pins, legend
+
+**Third-party scripts must be self-hosted.** Every page sets `script-src 'self'` in its CSP, so a CDN `<script>` is blocked — REDESIGN.md predates the policy and §6.6's "Leaflet via CDN" is not possible. Leaflet is vendored in `resources/vendor/leaflet/` (see its README). Check the page's `<meta http-equiv="Content-Security-Policy">` before planning anything third-party.
 
 ### CI/CD gates (branch-specific, see `.github/workflows/`)
 

--- a/docs/redesign-components.md
+++ b/docs/redesign-components.md
@@ -1,8 +1,12 @@
 # Redesign Shared Components
 
-> **Status:** Epic 3 complete — every component below is built, tested and merged to `staging`.
-> **Not yet wired:** no page fetches data into these components yet. That is Epic 4 (#294–#299).
+> **Status:** Epics 3 and 4 complete on `staging`. Every component below is
+> built and tested, and **Pop-Ups wires all of them to live data** (#294–#299) —
+> read `pop-ups.html` and its `popups-*.js` modules as the worked example.
+> **Not yet wired:** Date Ideas (Epic 6) and Home (Epic 7).
 > **Spec:** `REDESIGN.md` §6. **Responsive targets:** `docs/RESPONSIVE-QA.md`.
+> **Note:** `REDESIGN.md` predates the site's CSP; where they conflict, the CSP
+> wins and the deviation is recorded in §5.
 
 Everything here is gated behind the redesign feature flag, which is **OFF in all
 environments**. Nothing in this document is user-visible today; append
@@ -166,6 +170,13 @@ Recorded so they are not re-litigated:
   chip exists.
 - **`.filter-chip__chevron`**, not the spec's `.filter-chip .chevron` — Stylelint
   enforces a BEM class pattern.
+- **Leaflet is vendored, not loaded from a CDN** (#299) — §6.6 says CDN, but
+  `script-src 'self'` blocks that. See `resources/vendor/leaflet/README.md`.
+- **`beauty` has no pin colour.** §6.6 colours seven categories; the schema has
+  eight. `beauty`, and anything added later, falls through to a neutral
+  `--nyc-pin-other` rather than disappearing from the map.
+- **The no-results state is derived** (#296) — §6.3 specifies only the results
+  count. It carries a message and a *Clear all filters* action.
 - **Dropdowns lead with an "All …" option** carrying an empty value (#295),
   per §6.3. Epic 3 shipped without one, so clearing a single filter meant
   re-selecting the active option — a gesture nobody discovers.


### PR DESCRIPTION
Docs only — no source or test changes. Full suite still green (352 unit, 192 e2e).

`CLAUDE.md` and `docs/redesign-components.md` both still described the state at the end of Epic 3. A fresh session reading either would have been actively misled:

- "Components publish events… **Nothing consumes them yet**; that is Epic 4" — all four are consumed now.
- "**`buttons.css` styles the bare `button` selector**… Tracked in #372" — retired in #372.
- No mention of the four `popups-*.js` modules, `popups-redesign.css`, `map.css`, or the vendored Leaflet.
- The components doc's header still read "**Not yet wired:** no page fetches data into these components yet."

## What changed

**`CLAUDE.md`**

- New *Pop-Ups page composition* section naming the four modules and their CSS, so the wired page is findable as the worked example.
- **Third-party scripts must be self-hosted** — every page sets `script-src 'self'`, so a CDN `<script>` is blocked and REDESIGN.md's §6.6 "Leaflet via CDN" is not possible. This will recur in later epics, so it belongs in the always-loaded file rather than only in a vendor README.
- The resolved `buttons.css` trap is replaced by the two that have each bitten twice: `height: 100%` inside an auto-sized grid area (#376, #380, plus the `min-height: 0` overflow corollary), and legacy element/id selectors reaching redesign components (#372, #294) with the snapshot-and-diff technique that made retiring one safe.
- Module list and the noon-UTC anchoring list both extended to include the new files.

**`docs/redesign-components.md`**

- Accurate status header: Epics 3 and 4 complete, Pop-Ups is the worked example, Date Ideas and Home still unwired. Plus a note that REDESIGN.md predates the CSP and the CSP wins.
- Three more recorded deviations: vendored Leaflet, `beauty` having no pin colour in §6.6, and the derived no-results state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
